### PR TITLE
fix: Captain 挂 AfterToolCallback 兜底子 agent 空响应 (null result 静默停摆)

### DIFF
--- a/service/engine/init.go
+++ b/service/engine/init.go
@@ -26,11 +26,9 @@ import (
 
 	"charm.land/glamour/v2"
 	ag "trpc.group/trpc-go/trpc-agent-go/agent"
-	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
-	agenttool "trpc.group/trpc-go/trpc-agent-go/tool/agent"
 	mcp "trpc.group/trpc-go/trpc-mcp-go"
 )
 
@@ -368,55 +366,10 @@ func (e *Engine) newRunner() {
 		(*e).Agentname,
 		func(ctx context.Context, ro ag.RunOptions) (ag.Agent, error) {
 			e.reload()
-			exploit, err := e.initexploit()
+			captain, err := e.InitTeam()
 			if err != nil {
 				return nil, err
 			}
-			postexploit, err := e.initpostexploit()
-			if err != nil {
-				return nil, err
-			}
-			recon, err := e.initRecon()
-			if err != nil {
-				return nil, err
-			}
-			scanner, err := e.initScanner()
-			if err != nil {
-				return nil, err
-			}
-			reproducer, err := e.initReproducer()
-			if err != nil {
-				return nil, err
-			}
-
-			subagents := []*llmagent.LLMAgent{exploit, postexploit, recon, scanner, reproducer}
-			subagentTools := []tool.Tool{}
-			for _, agent := range subagents {
-				subagentTools = append(subagentTools, agenttool.NewTool(
-					agent,
-					agenttool.WithStreamInner(true), // 开启：把子 Agent 的流式事件转发给父流程
-					agenttool.WithInnerTextMode(agenttool.InnerTextModeInclude), //展示子agent完整transcript(正文+tool call+tool result)
-					agenttool.WithDescription(agent.Info().Description),
-					agenttool.WithPersistentHistory(),                          //在 HistoryScopeIsolated 下使用稳定的子 FilterKey，让子 Agent 能在同一个 session 内跨多次 AgentTool 调用读取自己的历史（而不是每次都从“全新子 key”开始）
-					agenttool.WithHistoryScope(agenttool.HistoryScopeIsolated), //子调用使用独立 FilterKey，通常只读取本次工具参数，不继承父历史
-				))
-			}
-
-			captain, err := e.initCaptain(subagentTools)
-			if err != nil {
-				return nil, err
-			}
-
-			/*
-				team.New(
-					captain,
-					[]ag.Agent{exploit, postexploit, recon, scanner, reproducer},
-					team.WithDescription("A hacker team with one captain and three members, responsible for penetration testing tasks."),
-					team.WithMemberToolStreamInner(true),                        //子agent的内部事件透传到父流程(TUI)
-					team.WithMemberToolInnerTextMode(team.InnerTextModeInclude), //展示子agent完整transcript(正文+tool call+tool result)
-				)
-			*/
-
 			return captain, nil
 		},
 		runner.WithSessionService((*e).SessionService_p),

--- a/service/engine/members.go
+++ b/service/engine/members.go
@@ -18,10 +18,88 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+	agenttool "trpc.group/trpc-go/trpc-agent-go/tool/agent"
 )
 
+type agentName string
+
+var (
+	captain     agentName = "Captain"
+	recon       agentName = "Recon"
+	exploit     agentName = "Exploit"
+	postexploit agentName = "PostExploit"
+	scanner     agentName = "Scanner"
+	reproducer  agentName = "Reproducer"
+)
+
+func (e *Engine) InitTeam() (*llmagent.LLMAgent, error) {
+	exploit, err := e.initexploit()
+	if err != nil {
+		return nil, err
+	}
+	postexploit, err := e.initpostexploit()
+	if err != nil {
+		return nil, err
+	}
+	recon, err := e.initRecon()
+	if err != nil {
+		return nil, err
+	}
+	scanner, err := e.initScanner()
+	if err != nil {
+		return nil, err
+	}
+	reproducer, err := e.initReproducer()
+	if err != nil {
+		return nil, err
+	}
+
+	subagents := []*llmagent.LLMAgent{exploit, postexploit, recon, scanner, reproducer}
+	subagentTools := []tool.Tool{}
+	for _, agent := range subagents {
+		subagentTools = append(subagentTools, agenttool.NewTool(
+			agent,
+			agenttool.WithStreamInner(true), // 开启：把子 Agent 的流式事件转发给父流程
+			agenttool.WithInnerTextMode(agenttool.InnerTextModeInclude), //展示子agent完整transcript(正文+tool call+tool result)
+			agenttool.WithDescription(agent.Info().Description),
+			agenttool.WithPersistentHistory(),                          //在 HistoryScopeIsolated 下使用稳定的子 FilterKey，让子 Agent 能在同一个 session 内跨多次 AgentTool 调用读取自己的历史（而不是每次都从“全新子 key”开始）
+			agenttool.WithHistoryScope(agenttool.HistoryScopeIsolated), //子调用使用独立 FilterKey，通常只读取本次工具参数，不继承父历史
+		))
+	}
+	toolCallbacks := tool.NewCallbacks().RegisterAfterTool(afterToolCallback)
+	captain, err := e.initCaptain(subagentTools, toolCallbacks)
+	if err != nil {
+		return nil, err
+	}
+	return captain, nil
+}
+
+func afterToolCallback(ctx context.Context, args *tool.AfterToolArgs) (*tool.AfterToolResult, error) {
+	if args.ToolName == string(recon) || args.ToolName == string(exploit) || args.ToolName == string(postexploit) || args.ToolName == string(scanner) || args.ToolName == string(reproducer) {
+		if args.Error != nil {
+			return nil, nil // 真失败放行：框架沿用原始 result+err 走原有错误路径
+		}
+
+		if args.Result == nil {
+			return &tool.AfterToolResult{
+				CustomResult: fmt.Sprintf("[AGENT %s returned EMPTY RESPONSE - likely a model "+"generation failure (empty content, no toolcalls). Task NOT completed. "+"This is usually transient: re-dispatch the SAME request up to 2 more times. "+"If it fails repeatedly, switch approach or report failure explicitly.]", args.ToolName),
+			}, nil
+		}
+		s, ok := args.Result.(string)
+		if ok {
+			if strings.TrimSpace(s) == "" {
+				return &tool.AfterToolResult{
+					CustomResult: fmt.Sprintf("[AGENT %s returned EMPTY RESPONSE - likely a model "+"generation failure (empty content, no toolcalls). Task NOT completed. "+"This is usually transient: re-dispatch the SAME request up to 2 more times. "+"If it fails repeatedly, switch approach or report failure explicitly.]", args.ToolName),
+				}, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
 // 创建队长agent，负责任务规划、分配和总结，队长只挂载文件目录及文件读写工具
-func (e *Engine) initCaptain(subagentTools []tool.Tool) (*llmagent.LLMAgent, error) {
+func (e *Engine) initCaptain(subagentTools []tool.Tool, toolCallbacks *tool.Callbacks) (*llmagent.LLMAgent, error) {
 	captainPrompt := e.assemblePrompt("prompts/agents/captain.md")
 
 	// 内置工具清单常驻（启动时建一次），拷入私有slice再追加记忆工具，避免与Engine共享列表产生append别名
@@ -48,9 +126,10 @@ func (e *Engine) initCaptain(subagentTools []tool.Tool) (*llmagent.LLMAgent, err
 		llmagent.WithEnableOnDemandSession(true),                         // 按需加载被压缩的原始数据（session_load）
 		llmagent.WithPreloadMemory(10),                                   // 预加载记忆到上下文中
 		llmagent.WithGlobalInstruction(captainPrompt),                    // 系统提示词
+		llmagent.WithToolCallbacks(toolCallbacks),
 		//llmagent.WithEnableParallelTools(true),        //队长启用子agent的并行调度能力
 	}
-	agent_p, err := setAgent("Captain", (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(captain, (*(*e).Config_p).Model, opts)
 	return agent_p, err
 
 }
@@ -92,7 +171,7 @@ func (e *Engine) initRecon() (*llmagent.LLMAgent, error) {
 			llmagent.SkillToolProfileKnowledgeOnly,
 		),
 	}
-	agent_p, err := setAgent("Recon", (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(recon, (*(*e).Config_p).Model, opts)
 	return agent_p, err
 }
 
@@ -133,7 +212,7 @@ func (e *Engine) initexploit() (*llmagent.LLMAgent, error) {
 			llmagent.SkillToolProfileKnowledgeOnly,
 		),
 	}
-	agent_p, err := setAgent("Exploit", (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(exploit, (*(*e).Config_p).Model, opts)
 	return agent_p, err
 
 }
@@ -175,7 +254,7 @@ func (e *Engine) initpostexploit() (*llmagent.LLMAgent, error) {
 			llmagent.SkillToolProfileKnowledgeOnly,
 		),
 	}
-	agent_p, err := setAgent("PostExploit", (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(postexploit, (*(*e).Config_p).Model, opts)
 	return agent_p, err
 }
 
@@ -216,7 +295,7 @@ func (e *Engine) initScanner() (*llmagent.LLMAgent, error) {
 			llmagent.SkillToolProfileKnowledgeOnly,
 		),
 	}
-	agent_p, err := setAgent("Scanner", (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(scanner, (*(*e).Config_p).Model, opts)
 	return agent_p, err
 }
 
@@ -254,24 +333,24 @@ func (e *Engine) initReproducer() (*llmagent.LLMAgent, error) {
 			llmagent.SkillToolProfileKnowledgeOnly,
 		),
 	}
-	agent_p, err := setAgent("Reproducer", (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(reproducer, (*(*e).Config_p).Model, opts)
 	return agent_p, err
 }
 
 // setAgent 根据 APIType 创建对应模型的 agent（无状态，包级函数）
-func setAgent(agentName string, m config.Model, opts []llmagent.Option) (*llmagent.LLMAgent, error) {
+func setAgent(agentName agentName, m config.Model, opts []llmagent.Option) (*llmagent.LLMAgent, error) {
 	opts = append(opts, setBeforeModelStatusCallback()) //设置beforeModel状态栏
 	if m.APIType == "openai" {
 		openaimodel := models.Openai(m)
 		opts = append(opts, llmagent.WithModel(openaimodel))
-		Agent_p := llmagent.New(agentName, opts...)
+		Agent_p := llmagent.New(string(agentName), opts...)
 		return Agent_p, nil
 
 	} else if m.APIType == "anthropic" {
 
 		Anthropicagent := models.Anthropic(m)
 		opts = append(opts, llmagent.WithModel(Anthropicagent))
-		Agent_p := llmagent.New(agentName, opts...)
+		Agent_p := llmagent.New(string(agentName), opts...)
 		return Agent_p, nil
 
 	} else {

--- a/service/engine/prompts/agents/captain.md
+++ b/service/engine/prompts/agents/captain.md
@@ -223,6 +223,16 @@ Example — to dispatch the Recon agent, emit this tool call (not text):
 
 The tool then forwards your directive to the sub-agent and returns its result. The target agent is determined **solely by which tool you call**, so do not include a `target_agent` field.
 
+## Sub-Agent Empty Response Handling
+
+A sub-agent tool result that is empty, literal `null`, or consists of the placeholder `[AGENT <name> returned EMPTY RESPONSE ...]` signals an **execution anomaly** (typically an upstream model generation failure) — it is **NEVER** a normal task completion. When you encounter one:
+
+1. Do **NOT** treat the task as done, move to the next phase, or conclude the engagement based on it.
+2. Re-dispatch the **same request** (same `task_id` with a retry suffix such as `-R1`/`-R2`, identical `details`) up to 2 more times.
+3. If it still returns empty after the retries, stop retrying: split the task into smaller subtasks, switch approach, or explicitly report the failure in your summary. **NEVER** end the campaign silently with an unexecuted task.
+
+Conversely, a non-empty reply alone proves nothing either — task completion is judged solely by the deliverables defined in the Quality Review Protocol below (result MD file + structured blocks), never by the mere presence of a response.
+
 ## Result File Reading & Quality Review Protocol
 
 After a sub-agent completes its task and reports the result file path in the conversation, you **MUST** strictly follow the steps below. **NEVER** make decisions based solely on conversation summaries:


### PR DESCRIPTION
根因: 子 agent 某轮 LLM 空生成(无 content 无 tool_calls) → 框架流式路径收集不到文本 → AgentTool 返回 Go nil → 序列化为字面量 null 回给 Captain → 连续 null 后静默收尾, 全程无 WARN/ERROR。

- 新增 afterToolCallback: 按 5 个子 agent 工具名过滤, args.Error!=nil 放行框架原有错误路径; Result 为 nil 或纯空白字符串时替换为明确的重试指令占位文本

- 团队组装逻辑从 newRunner() 抽为 Engine.InitTeam(), agent 名改用 agentName 常量

- captain.md 增补 Sub-Agent Empty Response Handling: 空/null/占位响应视为执行异常禁止收尾, 同请求重试最多 2 次, 失败须显式上报