### PR TITLE
feat: TUI 优化与重构整体移植自 HyperBot v3.0.0（新布局/重绘节流/TodoBar/启动横幅/错误重试）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,3 +160,18 @@ HackerTeam uses three complementary mechanisms to prevent context overflow:
 - **Note**: tiktoken `cl100k_base` vs DeepSeek API token count differs ~4-7% (empirically verified) — not accurate enough to explain 2x+ discrepancies
 - **Root cause pattern**: first summary attempt fails → delta grows unbounded → cascade failure → permanent retry loop
 - **Fix priority**: (1) enable Context Compaction for tool result size control, (2) lower `CheckTokenThresholdPercent` if needed, (3) use non-reasoning model for summarization as last resort
+
+## TUI v3（整体移植自 HyperBot v3.0.0, commit 9f829f1 "优化TUI展示"）
+
+- **新布局** — `service/tui/tui.go`。`MainFlex`(FlexRow) 四段：`AgentMessage`(弹性) + `TodoBar`(0~N 行动态) + `NoticeBar`(1 行常驻) + `InputRow`(1 行，左侧 2 列运行指示器 `indicator` + `InputArea`)。装饰性 StatusBar 与右侧 InputHint 已移除，键位提示由 NoticeBar 常驻 hint 承担。
+- **重绘节流** — 所有 widget 写入走 `QueueUpdate`（只写不画）→ `markDirty()` → `drawLoop`（30ms）按 `dirty` 原子标志节流 `app.Draw()`。`markDirty()` 必须在写入完成**之后**调用；drawLoop 不能删（纯流式输出期间 tview 不会自行重绘）。它身兼重绘/spinner 动画/TodoBar/NoticeBar 四职，单 ticker 驱动，私有状态收在 drawLoop 局部 `drawState`，无需加锁。
+- **glamour** — `glamourRenderer()` 按消息区宽度缓存 renderer；宽度必须在 `app.QueueUpdate` 内读（`GetInnerRect` 无锁，跨 goroutine 读是数据竞争）。渲染失败退回原文（`messagerender/messageRender.go`），不要吞掉整条回复。
+- **TodoBar/NoticeBar** — TodoBar 纵向每个任务一行，高度 0↔N 行（`ResizeItem`，proportion 必须 0；矮终端按 `minMessageRows=3` 钳制负高度）；NoticeBar 固定 1 行永不塌陷。多行 SetText 后必须 `ScrollToBeginning()`；`SetWrap(false)` 是刻意的（行数可精确计算）。
+- **todoTextSink** — `status.go` 的 `injectTodoStatus` 把 `TodoStatusBar` 输出同时注入 prompt 尾部与推给 sink。**空串也要推**（清单清空时 TodoBar 靠空串塌回 0 行）。装配约定：`members.go` 的 `setAgent(..., sink)` 只有 Captain 传 `(*e).tui`，五个子 agent 传 nil —— 子 agent 按 branch 读不到清单，每跳推空串会清掉 Captain 的显示造成闪烁；prompt 注入不受影响。
+- **转义契约** — `ShowNotice` 收受信 markup（`pretty.TBarXxx`），**不转义**；`SetTodoText` 收框架/LLM 纯文本，**必须 `tview.Escape`**（否则 `[TODO]`、`[urgent]` 等会被 tview 当颜色标签整个吞掉）。转义只放 TUI 边界，绝不放进 `renderTodoStatusBar`（输出同时喂 prompt）。宽度度量用 `tview.TaggedStringWidth` 且必须先 Escape 再度量。
+- **错误自动重试** — `engineCore.go` 常量 `errorMaxTimes=3`/`errorSleepGap=3s` + `Engine.errorStreak`。归零时机四个：一轮成功(Continue)、/new、ESC(Int)、用户提交非空输入；只有自动重试链内部不归零。耗尽后 Code 保持 Error、streak 不归零、整个复用 `*EndTurn_p`。`agentRunIteratively` 输入循环是"Error 优先 + else 兜底"结构，不要改回列举式（新增 turnCode 会落进安全兜底）。
+- **启动横幅** — `service/tui/banner.go`。挂在 `Startup` turnCode 上（该 code 永远不会被 `agentRunIteratively` 返回，横幅必然只打一次）；Engine 侧 `startupInfoLines()` 决定内容（skills 数为 5 个角色文件夹子目录计数），TUI 侧 `compose(width)` 决定拼版；横幅是"死文本"，resize 不重排。
+- **输入复用** — `InputChan` 改为未导出 `inputChan`；`ReadInputAreaPromptWithEnter()+InputChannel()` 合并为 `ListenUserInput() chan string`。引擎循环 `select { case userPrompt = <-(*e).tui.ListenUserInput(): }`。unbuffered + select-default 投递语义不变。
+- **系统消息不带装饰符号** — `pretty.go` 状态消息/生命周期两节去掉 `✗ ✓ ⚠ ◈` 前缀与 `::b`，语义由颜色承载；对话内容标记（▶ ● ↪ ⮡ »«）保留。新增 bar 版 helper：`TBarNewConversation/TBarCancelled/TBarSuccess`（无首尾换行）。
+- **每类事件只打一次** — 错误在 `agentRunOnce` 源头各打一次（RunError/TerminalError），中断在 `Ctx.Done` 分支打一次；`agentRunIteratively` 顶部只处理 Startup（横幅）与 New（通知），Error/Int 不再重复打印。
+- **接口收敛** — `init.go` 的 tuiService 是 Engine 专属门面（新增 ListenUserInput/SetAgentRunning/ShowNotice/ShowStartupBanner/SetTodoText；移除 ReadInputAreaPromptWithEnter/InputChannel/ShowSuccessInMsgView/StatusBar*）；session 包持有单方法 `msgPrinter` 小接口。`ShowSuccessInMsgView` 已删除（职责迁去 NoticeBar），`ShowSuccessInMsgViewAndExit` 保留。

--- a/service/engine/engineCore.go
+++ b/service/engine/engineCore.go
@@ -3,7 +3,11 @@ package engine
 import (
 	"context"
 	"embed"
+	"fmt"
+	"net/url"
 	"os"
+	"strings"
+	"time"
 
 	"HackerTeam/service/engine/config"
 	"HackerTeam/utils/pretty"
@@ -15,6 +19,13 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
+// 连续错误自动重试策略。达到上限后不再自动重试，把控制权交还用户。
+// 用常量而非 yaml 配置：目前没有按实例调整的需求，将来要配再提升为 Engine 字段。
+const (
+	errorMaxTimes = 3
+	errorSleepGap = 3 * time.Second
+)
+
 type Agentrunner struct {
 	Runner runner.Runner
 	Stream bool
@@ -22,6 +33,12 @@ type Agentrunner struct {
 
 // Engine 封装核心状态变量（原 global 包级变量）
 type Engine struct {
+	// errorStreak 当前连续错误次数，配合 errorMaxTimes / errorSleepGap
+	// 实现自动重试的上限与退避。归零时机有四个，缺一不可：一轮成功(Continue)、/new、
+	// 用户 ESC 中断(Int)、用户在 agentRunIteratively 提交一条非空输入。
+	// 只有"自动重试链"内部不归零——那正是要计数的时候。
+	errorStreak int
+
 	tui tuiService
 
 	Config_p             *config.Config           //yaml配置
@@ -70,10 +87,12 @@ func GetEngineService(name string, tui tuiService) *Engine {
 }
 
 func (e *Engine) AgentStart() {
-	MsgContext := turnResult{
-		Code:       New,
-		Reason:     "新对话",
-		OutputPart: "",
+	// 初始用 Startup 而不是 New：程序刚启动时并不存在"上一轮对话"，
+	// 推一条"新对话已开始"到 NoticeBar 是噪音。New 只留给用户真的敲 /new 的场合。
+	MsgContext := turnInfo{
+		Code:          Startup,
+		Reason:        "程序启动",
+		PartialOutput: "",
 	}
 	e.randomStartID()
 	for {
@@ -90,14 +109,38 @@ func (e *Engine) AgentStart() {
 			(*e).tui.ShowMsgAndExitNoTrigger(pretty.TExit("对话已结束，感谢使用！后会有期！"))
 
 		} else if (*EndTurn_p).Code == New { //用户开始新对话，重置SessionId, RequestId，更新MsgContext为新对话的初始状态
+			// /new 在 agentRunIteratively 的输入分支里是提前 return 的，走不到"用户提交
+			// 非空输入"那处归零，所以必须在这里单独归
+			(*e).errorStreak = 0
 			e.randomStartID()
-			MsgContext = turnResult{
-				Code:       New,
-				Reason:     "新对话",
-				OutputPart: "",
+			MsgContext = turnInfo{
+				Code:          New,
+				Reason:        "新对话",
+				PartialOutput: "",
 			}
 
-		} else { //其他情况，继续使用当前的SessionId, RequestId，更新MsgContext为当前对话的结束状态，供下一轮对话使用
+		} else if (*EndTurn_p).Code == Error { //出错：累加连续错误计数，未达上限则退避后自动重试
+			(*e).errorStreak++
+			if (*e).errorStreak >= errorMaxTimes {
+				// 放弃自动重试，把控制权交还用户。三个要点：
+				// ① Code 保持 Error —— Int 的语义是"用户按了 ESC 中断"，与事实不符，
+				//    不能为了蹭"回到输入循环"这个副作用而填一个假状态码。真正让下一轮
+				//    等用户输入的是 agentRunIteratively 里的 errorStreak < errorMaxTimes 判定。
+				// ② errorStreak 不归零 —— 归零会让下一轮重新满足自动重试条件，无限循环照旧。
+				// ③ 整个复用 *EndTurn_p，不新造 literal —— 新建会静默丢掉 Reason 与 PartialOutput。
+				(*e).tui.PrintToMsgView(pretty.TErrorF("连续 %d 次失败，已停止自动重试。请检查网络/配置后重新输入。", errorMaxTimes), false)
+				MsgContext = *EndTurn_p
+				continue
+			}
+			// 必须在 Sleep 之前打：sleep 期间引擎 goroutine 阻塞、不监听输入通道，
+			// 用户打字没有反应，需要知道程序在等什么。
+			(*e).tui.PrintToMsgView(pretty.TWarningF("%d 秒后重试（第 %d/%d 次）...", errorSleepGap/time.Second, (*e).errorStreak, errorMaxTimes), false)
+			time.Sleep(errorSleepGap)
+			MsgContext = *EndTurn_p
+
+		} else { //其他情况（Continue 正常结束 / Int 用户中断），错误链断开、计数归零
+			// 归零覆盖两个时机：Continue（自动重试链里第 2 次尝试成功时收口）与 Int（人已介入）
+			(*e).errorStreak = 0
 			MsgContext = *EndTurn_p
 			continue
 		}
@@ -108,4 +151,44 @@ func (e *Engine) AgentStart() {
 func (e *Engine) randomStartID() {
 	(*e).SessionId = uuid.New().String()
 	(*e).RequestId = uuid.New().String()
+}
+
+// startupInfoLines 拼出启动横幅的信息行（label 补齐到 13 列），宽度截断交给 TUI。
+// 调用时机在 AgentStart 第一轮，此时 preCheckLoad/newRunner/randomStartID 均已完成。
+func (e *Engine) startupInfoLines() []string {
+	cfg := (*e).Config_p.Model
+	cwd := (*e).CWD
+	if home, err := os.UserHomeDir(); err == nil && strings.HasPrefix(cwd, home) {
+		cwd = "~" + cwd[len(home):]
+	}
+	sid := (*e).SessionId
+	if len(sid) > 8 {
+		sid = sid[:8]
+	}
+	// 统计 5 个角色 skills 文件夹下的 skill 数量（每个 skill 是一个子目录）
+	skills := 0
+	for _, dir := range []string{(*e).ReconSkillsFolderPath, (*e).ExploitSkillsFolderPath,
+		(*e).PostExploitSkillsFolderPath, (*e).ScannerSkillsFolderPath, (*e).ReproducerSkillsFolderPath} {
+		if entries, err := os.ReadDir(dir); err == nil {
+			for _, en := range entries {
+				if en.IsDir() {
+					skills++
+				}
+			}
+		}
+	}
+	host, err := url.Parse(cfg.BaseURL)
+	if err != nil {
+		host = &url.URL{Host: ""}
+	}
+	return []string{
+		fmt.Sprintf("model        %s %d", cfg.Model, cfg.ContextWindow),
+		fmt.Sprintf("endpoint     %s", host.Host),
+		fmt.Sprintf("cwd          %s", cwd),
+		fmt.Sprintf("tools        %d · skills %d · mcp %d",
+			len((*e).builtinTools)+len((*e).builtinToolsets),
+			skills,
+			len((*e).mcpToolsets)),
+		fmt.Sprintf("session      %s", sid),
+	}
 }

--- a/service/engine/engineRun.go
+++ b/service/engine/engineRun.go
@@ -10,15 +10,19 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
-type turnResult struct {
-	Code       turnCode
-	Reason     string
-	OutputPart string
+type turnInfo struct {
+	Code          turnCode
+	Reason        string
+	PartialOutput string
 }
 type turnCode int
 
+// turnCode 一轮对话的结束状态，决定下一轮 agentRunIteratively 的行为。
+// Startup 刻意取 0：turnInfo 的零值就是它，未显式设置 Code 时会落到最安静、
+// 最安全的默认行为（不推通知、等用户输入）。
 const (
-	New      turnCode = 1 //新对话
+	Startup  turnCode = 0 //程序启动，尚未有任何一轮对话
+	New      turnCode = 1 //新对话（用户敲 /new）
 	Int      turnCode = 2 //用户中断
 	Error    turnCode = 3 //错误
 	Exit     turnCode = 4 //用户退出
@@ -26,24 +30,45 @@ const (
 )
 
 // 交互式对话
-func (e *Engine) agentRunIteratively(Ctx context.Context, inputContext turnResult) *turnResult {
+func (e *Engine) agentRunIteratively(Ctx context.Context, inputContext turnInfo) *turnInfo {
 	Ctx, cancel := context.WithCancel(Ctx)
 	defer cancel()
-	//根据传入消息的类型输出不同提示语
-	if inputContext.Code == New {
-		(*e).tui.PrintToMsgView(pretty.TNewConversation(), false)
-	} else if inputContext.Code == Error {
-		(*e).tui.PrintToMsgView(pretty.TErrorF("对话发生错误: %s", inputContext.Reason), false)
-	} else if inputContext.Code == Int { //对话因中断信号而中断,不输出提示语
+	//Startup 只在启动那一轮出现且不会被本函数返回，横幅必然只打印一次；
+	//New（用户敲 /new）才推"新对话已开始"，刚启动时没有"上一轮对话"，推了是噪音。
+	//Error 与 Int 不在这里打印——各自已在 agentRunOnce 里打过，再打就是重复。
+	if inputContext.Code == Startup {
+		(*e).tui.ShowStartupBanner((*e).startupInfoLines())
+	} else if inputContext.Code == New {
+		(*e).tui.ShowNotice(pretty.TBarNewConversation())
 	}
 
 	var userPrompt string
 	for {
-		//如果是新对话、继续对话或中断后恢复，用户自行输入prompt
-		if inputContext.Code == New || inputContext.Code == Continue || inputContext.Code == Int {
-			(*e).tui.ReadInputAreaPromptWithEnter() //启用输入框并将用户输入放进Channel
+		// Error 且还有重试预算：自动构造重试 prompt，不打扰用户。
+		// 其余全部情况（New / Continue / Int / 重试已耗尽）都走 else 回到输入循环等用户。
+		//
+		// 这里刻意用 "Error 优先 + else 兜底"，而不是列举 New||Continue||Int：
+		// ① 原来的写法没有最终 else，而 inputContext 是入参、循环体内从不被重新赋值，
+		//    一旦有未列举的 code 走进来，两个分支都不执行 → 循环体空转、100% CPU。
+		//    今天 Exit 到不了这里只是因为 showMsgAndExit 末尾的 select{} 永久阻塞，
+		//    那是个脆弱前提。
+		// ② 兜底分支是"等用户输入"，比"自动构造 prompt 再打一次 API"安全得多：
+		//    将来新增 turnCode 忘记登记，后果是多等一次用户输入，而不是无上限烧 API。
+		//
+		// 预算判定刻意内联、不抽中间变量：errorStreak 只在下面"提交非空输入"那条路上
+		// 归零，而那条路紧接着 break 出循环、不会重新求值；空输入走 continue 时
+		// errorStreak 未被修改，第二次判定结果一致。所以内联与循环外算一次等价。
+		if inputContext.Code == Error && (*e).errorStreak < errorMaxTimes {
+			if inputContext.PartialOutput != "" {
+				userPrompt = fmt.Sprintf("之前的对话发生了错误，错误信息是: %s, 之前的输出内容是: %s, 请基于这些信息调整你的回答并继续完成对话", inputContext.Reason, inputContext.PartialOutput)
+			} else {
+				userPrompt = fmt.Sprintf("之前的对话发生了错误，错误信息是: %s, 请基于这个信息调整你的回答并继续完成对话", inputContext.Reason)
+			}
+			break
+
+		} else {
 			select {
-			case userPrompt = <-(*e).tui.InputChannel():
+			case userPrompt = <-(*e).tui.ListenUserInput(): //启用输入框并将用户输入放进Channel
 
 			}
 
@@ -51,15 +76,16 @@ func (e *Engine) agentRunIteratively(Ctx context.Context, inputContext turnResul
 				checkprompt := strings.ReplaceAll(userPrompt, "\n", "")
 				checkprompt = strings.ReplaceAll(checkprompt, " ", "")
 				if checkprompt == "/exit" {
-					(*e).tui.PrintToMsgView(pretty.TColoredText(pretty.TColorLightGreen, fmt.Sprintf("\n%s%s\n", pretty.SymbolBullet, checkprompt)), false)
-					return &turnResult{
-						Code:   Exit,
-						Reason: "用户主动结束对话",
+					(*e).tui.PrintToMsgView(pretty.TColoredText(pretty.TColorLightGreen, fmt.Sprintf("\n%s\n", checkprompt)), false)
+					return &turnInfo{
+						Code:          Exit,
+						Reason:        "用户主动结束对话",
+						PartialOutput: "",
 					}
 
 				} else if checkprompt == "/new" {
-					(*e).tui.PrintToMsgView(pretty.TColoredText(pretty.TColorLightGreen, fmt.Sprintf("\n%s%s\n", pretty.SymbolBullet, checkprompt)), false)
-					return &turnResult{
+					(*e).tui.PrintToMsgView(pretty.TColoredText(pretty.TColorLightGreen, fmt.Sprintf("\n%s\n", checkprompt)), false)
+					return &turnInfo{
 						Code:   New,
 						Reason: "用户主动开始新对话",
 					}
@@ -68,18 +94,13 @@ func (e *Engine) agentRunIteratively(Ctx context.Context, inputContext turnResul
 					continue //如果用户输入为空，重新开始本轮循环，等待用户输入
 
 				} else {
+					// 用户手动提交了一次新输入，给这一轮一份全新的重试预算。
+					// 只对"重试已耗尽"路径有实际意义（其余路径 errorStreak 本来就是 0）。
+					(*e).errorStreak = 0
 					(*e).tui.PrintToMsgView(pretty.TUserInput(userPrompt), false)
 					break //正常输入，继续执行后续逻辑
 				}
 			}
-
-		} else if inputContext.Code == Error {
-			if inputContext.OutputPart != "" {
-				userPrompt = fmt.Sprintf("之前的对话发生了错误，错误信息是: %s, 之前的输出内容是: %s, 请基于这些信息调整你的回答并继续完成对话", inputContext.Reason, inputContext.OutputPart)
-			} else {
-				userPrompt = fmt.Sprintf("之前的对话发生了错误，错误信息是: %s, 请基于这个信息调整你的回答并继续完成对话", inputContext.Reason)
-			}
-			break
 		}
 	}
 
@@ -88,21 +109,27 @@ func (e *Engine) agentRunIteratively(Ctx context.Context, inputContext turnResul
 	// 函数返回前清除应用级捕获器，避免ESC事件被持续拦截
 	defer (*e).tui.ClearAppFuncTrigger()
 
-	// AgentRunOnce返回的消息包含本次对话输入输出的所有消息
+	// AgentRunOnce返回的消息包含本次对话输入输出的所有消息。
+	// 运行指示器的开关紧贴这次调用：用 defer 复位是为了 panic 安全——agentRunOnce
+	// 内部跑的是框架代码，panic 时指示器会永远转下去。
+	// 不要挂到本函数开头那个 Ctx 上：那个 ctx 的生命周期包含前面等用户输入的阶段，
+	// 挂上去 spinner 会在用户还没打字时就转起来。
+	(*e).tui.SetAgentRunning(true)
+	defer (*e).tui.SetAgentRunning(false)
 	AgentError_p := e.agentRunOnce(Ctx, userPrompt)
 	if AgentError_p != nil { //如果运行过程中发生错误
-		return &turnResult{
-			Code:       Error,
-			Reason:     fmt.Sprintf("对话过程中发生错误: %v", (*AgentError_p).Error),
-			OutputPart: (*AgentError_p).OutputPart,
+		return &turnInfo{
+			Code:          Error,
+			Reason:        fmt.Sprintf("对话过程中发生错误: %v", (*AgentError_p).Error),
+			PartialOutput: (*AgentError_p).PartialOutput,
 		}
 	}
 
-	//如果ctx被取消，则设置结束状态为中断
+	//如果ctx被取消，则设置结束状态为中断。
+	//提示语已由 agentRunOnce 的 Ctx.Done 分支打过（"会话已取消"），这里不再重复。
 	select {
 	case <-Ctx.Done():
-		(*e).tui.PrintToMsgView(pretty.TInterrupted(), false)
-		return &turnResult{
+		return &turnInfo{
 			Code:   Int,
 			Reason: "会话已取消，停止接收输入",
 		}
@@ -110,7 +137,7 @@ func (e *Engine) agentRunIteratively(Ctx context.Context, inputContext turnResul
 	}
 
 	//单轮对话正常结束，设置状态为continue，session自动维护历史
-	return &turnResult{
+	return &turnInfo{
 		Code:   Continue,
 		Reason: "单轮对话正常结束",
 	}
@@ -118,18 +145,12 @@ func (e *Engine) agentRunIteratively(Ctx context.Context, inputContext turnResul
 }
 
 type AgentError struct {
-	Error      error
-	ErrorType  string
-	OutputPart string
+	Error         error
+	ErrorType     string
+	PartialOutput string
 }
 
 func (e *Engine) agentRunOnce(Ctx context.Context, userPrompt string) *AgentError {
-	// 修改状态栏提示，显示正在运行中
-	statusBarCtx := context.Background()
-	statusBarCtx, cancel := context.WithCancel(statusBarCtx)
-	defer cancel() // 确保函数退出时取消状态栏提示的上下文
-	go (*e).tui.StatusBarScrollingTip(statusBarCtx, "Processing....", pretty.TColorLightMagenta)
-
 	eventChan, err := (*(*e).AgentRunner_p).Runner.Run(
 		Ctx,
 		(*(*e).Config_p).User.UserID,
@@ -138,19 +159,24 @@ func (e *Engine) agentRunOnce(Ctx context.Context, userPrompt string) *AgentErro
 			Role:    model.RoleUser,
 			Content: userPrompt,
 		},
-		agent.WithRequestID((*e).RequestId),
+		agent.WithRequestID((*e).RequestId), //HackerTeam 保留 RequestId 机制（区别于 HyperBot v3 的删除）
 		agent.WithToolCallArgumentsJSONRepairEnabled(true), //开启工具调用参数的JSON修复功能，解决因模型输出格式不规范导致的工具调用失败问题
 	)
 	if err != nil {
+		err = fmt.Errorf("AgentRunner.Run发生错误: %v", err)
+		// 在源头打印，与下面的 TerminalError 分支保持一致：每类错误只打一次。
+		// 改前这里不打，只靠 agentRunIteratively 循环顶部打一次，与 TerminalError
+		// 打两次的行为不一致。
+		(*e).tui.PrintToMsgView(pretty.TErrorF("%v", err), false)
 		return &AgentError{
-			Error:      fmt.Errorf("AgentRunner.Run发生错误: %v", err),
-			ErrorType:  "RunError",
-			OutputPart: "",
+			Error:         err,
+			ErrorType:     "RunError",
+			PartialOutput: "",
 		}
 	}
 
-	OutputPart := ""
-	msgRender := messagerender.NewMessageRender((*e).tui, (*(*e).Config_p).Model.ShowReasoning, (*(*e).Config_p).Model.Stream)
+	partialOutput := ""
+	msgRender := messagerender.NewMessageRender((*e).tui, (*(*e).Config_p).Model.ShowReasoning, (*(*e).AgentRunner_p).Stream)
 	for event := range eventChan {
 		//只有terminal error才会中断对话，其他error直接continue
 		if event.Error != nil {
@@ -159,9 +185,9 @@ func (e *Engine) agentRunOnce(Ctx context.Context, userPrompt string) *AgentErro
 				err = fmt.Errorf("Event发生TerminalError: %v", event.Error)
 				(*e).tui.PrintToMsgView(pretty.TErrorF("%v", err), false)
 				return &AgentError{
-					Error:      err,
-					ErrorType:  "TerminalError",
-					OutputPart: OutputPart,
+					Error:         err,
+					ErrorType:     "TerminalError",
+					PartialOutput: partialOutput,
 				}
 			} else {
 				continue
@@ -170,7 +196,7 @@ func (e *Engine) agentRunOnce(Ctx context.Context, userPrompt string) *AgentErro
 		}
 		select {
 		case <-Ctx.Done():
-			(*e).tui.PrintToMsgView(pretty.TCancelled(), false)
+			(*e).tui.ShowNotice(pretty.TBarCancelled())
 			return nil
 
 		default:
@@ -180,7 +206,7 @@ func (e *Engine) agentRunOnce(Ctx context.Context, userPrompt string) *AgentErro
 			for _, choice := range (*(*event).Response).Choices {
 
 				msgRender.RenderResponse(choice)
-				gatherContentMessage(&OutputPart, choice, (*(*e).AgentRunner_p).Stream)
+				gatherPartialOutput(&partialOutput, choice, (*(*e).AgentRunner_p).Stream)
 			}
 
 		}
@@ -195,8 +221,16 @@ func (e *Engine) agentRunOnce(Ctx context.Context, userPrompt string) *AgentErro
 
 }
 
-// 收集输出正文，如果出现错误，可以通过这段文本在下一轮对llm进行提示，帮助模型更好地理解之前发生了什么，从而调整后续输出
-func gatherContentMessage(Container_p *string, Choice model.Choice, Stream bool) {
+// 收集失败前已产出的部分输出。出现错误时通过这段文本在下一轮对 llm 进行提示，
+// 帮助模型理解之前发生了什么，从而调整后续输出。
+//
+// 不能删、也不能靠框架 session 代替：流式 delta 一律不落盘（框架 shouldPersistEvent
+// 要求 !IsPartial），中途失败时那个"完整最终 event"根本没产生，这一轮 assistant 文本
+// 在 session 里一个字都没有。框架的补救机制 WithPersistInterruptedAssistant 默认关闭、
+// 本项目未开启，且它只在 ctx 被取消时触发，覆盖不到 TerminalError。所以这里是唯一记录。
+//
+// 注意只累积 Choice 的 Content —— 不含 ReasoningContent，也不含 ToolCalls。
+func gatherPartialOutput(Container_p *string, Choice model.Choice, Stream bool) {
 	if Stream {
 		*Container_p += Choice.Delta.Content
 	} else {

--- a/service/engine/init.go
+++ b/service/engine/init.go
@@ -36,16 +36,16 @@ type tuiService interface {
 	AddHelpItems(items []map[string]string)
 	ClearAppFuncTrigger()
 	PrintToMsgView(content string, clear bool)
-	ReadInputAreaPromptWithEnter()
-	InputChannel() chan string
+	ListenUserInput() chan string
+	SetAgentRunning(running bool)
+	ShowNotice(msg string)
+	ShowStartupBanner(infoLines []string)
+	SetTodoText(text string)
 	ResetHelpItems()
 	SetAppFuncTriggerWithEsc(f func())
 	ShowErrorInMsgViewAndExit(errmsg string)
 	ShowMsgAndExitNoTrigger(msg string)
-	ShowSuccessInMsgView(sussessmsg string)
 	ShowSuccessInMsgViewAndExit(sussessmsg string)
-	StatusBarScrollingTip(ctx context.Context, tip string, TColor string)
-	StatusBarUserTip(s string)
 	RenderMarkdown(in string) (string, error)
 }
 
@@ -249,7 +249,7 @@ func (e *Engine) checkConfigFolder() {
 			if err != nil {
 				(*e).tui.ShowErrorInMsgViewAndExit(pretty.TErrorF("创建默认config文件夹错误：%v", err))
 			}
-			(*e).tui.ShowSuccessInMsgView("检查到config文件夹不存在，已创建默认config文件夹")
+			(*e).tui.ShowNotice(pretty.TBarSuccess("config folder not found, created default"))
 		} else {
 			(*e).tui.ShowErrorInMsgViewAndExit(pretty.TErrorF("检查config文件夹错误：%v", err))
 		}
@@ -324,7 +324,7 @@ func (e *Engine) checkSkillsFolder() {
 						(*e).tui.ShowErrorInMsgViewAndExit(pretty.TErrorF("修正%s文件夹权限错误：%s", pf.roleFolder, err.Error()))
 					}
 				}
-				(*e).tui.ShowSuccessInMsgView(fmt.Sprintf("检查到%s文件夹不存在，已创建", pf.roleFolder))
+				(*e).tui.ShowNotice(pretty.TBarSuccess(fmt.Sprintf("%s folder not found, created default", filepath.Base(pf.roleFolder))))
 			} else {
 				(*e).tui.ShowErrorInMsgViewAndExit(pretty.TErrorF("检查%s文件夹错误：%s", pf.roleFolder, err.Error()))
 			}

--- a/service/engine/members.go
+++ b/service/engine/members.go
@@ -126,7 +126,7 @@ func (e *Engine) initCaptain(subagentTools []tool.Tool, toolCallbacks *tool.Call
 		llmagent.WithToolCallbacks(toolCallbacks),
 		//llmagent.WithEnableParallelTools(true),        //队长启用子agent的并行调度能力
 	}
-	agent_p, err := setAgent(captain, (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(captain, (*(*e).Config_p).Model, opts, (*e).tui)
 	return agent_p, err
 
 }
@@ -168,7 +168,7 @@ func (e *Engine) initRecon() (*llmagent.LLMAgent, error) {
 			llmagent.SkillToolProfileKnowledgeOnly,
 		),
 	}
-	agent_p, err := setAgent(recon, (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(recon, (*(*e).Config_p).Model, opts, nil)
 	return agent_p, err
 }
 
@@ -209,7 +209,7 @@ func (e *Engine) initexploit() (*llmagent.LLMAgent, error) {
 			llmagent.SkillToolProfileKnowledgeOnly,
 		),
 	}
-	agent_p, err := setAgent(exploit, (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(exploit, (*(*e).Config_p).Model, opts, nil)
 	return agent_p, err
 
 }
@@ -251,7 +251,7 @@ func (e *Engine) initpostexploit() (*llmagent.LLMAgent, error) {
 			llmagent.SkillToolProfileKnowledgeOnly,
 		),
 	}
-	agent_p, err := setAgent(postexploit, (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(postexploit, (*(*e).Config_p).Model, opts, nil)
 	return agent_p, err
 }
 
@@ -292,7 +292,7 @@ func (e *Engine) initScanner() (*llmagent.LLMAgent, error) {
 			llmagent.SkillToolProfileKnowledgeOnly,
 		),
 	}
-	agent_p, err := setAgent(scanner, (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(scanner, (*(*e).Config_p).Model, opts, nil)
 	return agent_p, err
 }
 
@@ -330,13 +330,16 @@ func (e *Engine) initReproducer() (*llmagent.LLMAgent, error) {
 			llmagent.SkillToolProfileKnowledgeOnly,
 		),
 	}
-	agent_p, err := setAgent(reproducer, (*(*e).Config_p).Model, opts)
+	agent_p, err := setAgent(reproducer, (*(*e).Config_p).Model, opts, nil)
 	return agent_p, err
 }
 
-// setAgent 根据 APIType 创建对应模型的 agent（无状态，包级函数）
-func setAgent(agentName agentName, m config.Model, opts []llmagent.Option) (*llmagent.LLMAgent, error) {
-	opts = append(opts, setBeforeModelStatusCallback()) //设置beforeModel状态栏
+// setAgent 根据 APIType 创建对应模型的 agent（无状态，包级函数）。
+// sink 用于把 TodoBar 文本推给 TUI：只有 Captain（主 agent，与用户对话、持有 todo 清单）
+// 传 (*e).tui；五个子 agent 传 nil —— 子 agent 按 branch 读不到清单，每跳推空串会把
+// TodoBar 清空再由 Captain 推回造成闪烁，且它们本就非交互。
+func setAgent(agentName agentName, m config.Model, opts []llmagent.Option, sink todoTextSink) (*llmagent.LLMAgent, error) {
+	opts = append(opts, setBeforeModelStatusCallback(sink)) //设置beforeModel状态栏
 	if m.APIType == "openai" {
 		openaimodel := models.Openai(m)
 		opts = append(opts, llmagent.WithModel(openaimodel))

--- a/service/engine/messagerender/messageRender.go
+++ b/service/engine/messagerender/messageRender.go
@@ -89,7 +89,11 @@ func (r *MessageRender) renderNonStreamEvent(Choice model.Choice) {
 	}
 	// 正文内容 - 使用 glamour 渲染 markdown，TranslateANSI 转为 tview 颜色标签
 	if strings.TrimSpace(Choice.Message.Content) != "" && Choice.Message.Role != "tool" {
-		out, _ := (*r).tui.RenderMarkdown(pretty.TContentNoneStreamTag(Choice.Message.Content))
+		body := pretty.TContentNoneStreamTag(Choice.Message.Content)
+		out, err := (*r).tui.RenderMarkdown(body)
+		if err != nil {
+			out = body // 渲染失败退回原文，别把整条回复吞掉
+		}
 		out = strings.TrimRight(out, "\n\r ")
 		(*r).tui.PrintToMsgView(tview.TranslateANSI(out)+"[-:-:-]", false)
 	}

--- a/service/engine/session/memSessionService.go
+++ b/service/engine/session/memSessionService.go
@@ -1,14 +1,15 @@
 package session
 
 import (
-	"context"
 	"HackerTeam/service/engine/config"
 	"time"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 )
 
 // NewMemorySessionService 创建一个基于内存的 SessionService 实例，使用自动摘要功能来管理会话上下文。
-func NewMemorySessionService(m config.Model, tui tuiService) *inmemory.SessionService {
+// NewMemorySessionService 创建一个基于内存的 SessionService 实例，使用自动摘要功能来管理会话上下文。
+// tui 只用于摘要生成后打一行提示，见 msgPrinter。
+func NewMemorySessionService(m config.Model, tui msgPrinter) *inmemory.SessionService {
 	MemSessionService := inmemory.NewSessionService(
 		inmemory.WithSummarizer(NewSummarizer(m, tui)),
 		inmemory.WithAsyncSummaryNum(2),
@@ -18,18 +19,3 @@ func NewMemorySessionService(m config.Model, tui tuiService) *inmemory.SessionSe
 	return MemSessionService
 }
 
-type tuiService interface {
-	AddHelpItems(items []map[string]string)
-	ClearAppFuncTrigger()
-	PrintToMsgView(content string, clear bool)
-	ReadInputAreaPromptWithEnter()
-	InputChannel() chan string
-	ResetHelpItems()
-	SetAppFuncTriggerWithEsc(f func())
-	ShowErrorInMsgViewAndExit(errmsg string)
-	ShowMsgAndExitNoTrigger(msg string)
-	ShowSuccessInMsgView(sussessmsg string)
-	ShowSuccessInMsgViewAndExit(sussessmsg string)
-	StatusBarScrollingTip(ctx context.Context, tip string, TColor string)
-	StatusBarUserTip(s string)
-}

--- a/service/engine/session/summarizer.go
+++ b/service/engine/session/summarizer.go
@@ -38,7 +38,13 @@ func initSummarizerPrompts() {
 	userSummarizerPrompt = string(userSummarizerPrompt_b)
 }
 
-func NewSummarizer(m config.Model, tui tuiService) summary.SessionSummarizer {
+// msgPrinter 本包对 TUI 的全部需求：摘要生成后往消息区打一行提示。
+// 在消费方按需声明小接口，而不是依赖 init.go 的 tuiService 胖接口。
+type msgPrinter interface {
+	PrintToMsgView(content string, clear bool)
+}
+
+func NewSummarizer(m config.Model, tui msgPrinter) summary.SessionSummarizer {
 	initSummarizerPrompts()
 	//设置tiktoken计算方式，默认的方式太不准确了
 	counter, _ := tiktoken.New(m.Model)

--- a/service/engine/status.go
+++ b/service/engine/status.go
@@ -24,19 +24,27 @@ const (
 	memoryEntryMaxRunes = 200
 )
 
+// todoTextSink 接收渲染好的 todo 文本，供 TUI 的 TodoBar 显示。
+// 在 engine 包内声明（1 个方法），避免把 init.go 的 tuiService 胖接口渗进调用方——
+// 状态回调只需要"能把文本推给 UI"这一个能力。
+// 非交互调用方（子 agent 装配）传 nil：仍然注入 prompt，只是不推 UI。
+type todoTextSink interface {
+	SetTodoText(text string)
+}
+
 // 注入模型调用前callback，在消息末尾追加当前状态栏（时间、工作目录、内存、todo清单、相关记忆）。
 // 注意：追加在末尾而非前置 —— 自动前缀缓存要求请求头部保持稳定，
 // 状态栏每次调用内容变化，放头部会破坏整个前缀缓存（实测：尾部99%命中 vs 头部0）。
 // 使用本功能必须关闭框架的 system 前置重排（openai.WithOptimizeForCache），否则
 // 尾部状态栏会被框架挪回头部、缓存收益失效；关闭位置：service/engine/models/openai.go。
 // 状态栏不进 session（仅存在于当次请求副本），不污染摘要/上下文压缩。
-func setBeforeModelStatusCallback() llmagent.Option {
+func setBeforeModelStatusCallback(sink todoTextSink) llmagent.Option {
 
 	modelCallbacks := model.NewCallbacks().RegisterBeforeModel(
 		func(ctx context.Context, args *model.BeforeModelArgs) (*model.BeforeModelResult, error) {
 			var status string
 			injectBaseStatus(ctx, &status)
-			injectTodoStatus(ctx, &status)
+			injectTodoStatus(ctx, sink, &status)
 			injectMemoryStatus(ctx, args.Request.Messages, &status)
 
 			args.Request.Messages = append(args.Request.Messages, model.NewSystemMessage(status)) //在末尾追加状态栏
@@ -72,8 +80,19 @@ func injectBaseStatus(_ context.Context, status *string) {
 // 追加当前agent的todo清单状态（todo_write写入session state，按invocation branch读取，
 // 无清单时为空串不追加）。清单变化只影响尾部消息，不破坏前缀缓存；
 // 同轮内工具写入后下一跳请求即生效，上下文压缩掉历史后清单也不会丢。
-func injectTodoStatus(ctx context.Context, status *string) {
-	if todoStatus := functionTools.TodoStatusBar(ctx); todoStatus != "" {
+//
+// 同一份文本推两个去处：注入 prompt 的 [STATUS] 尾部，以及推给 sink 让 TodoBar 显示。
+// 因此 todo.go 不需要任何改动，也不需要渲染两份。
+//
+// ⚠️ 空串也要推给 sink：清单做完后 TodoStatusBar 返回 ""（todo_write 在全 completed
+// 时自动清空清单），TodoBar 靠这个空串把高度收回 0。只在非空时推的话，
+// bar 会永远挂着最后一版内容、高度也收不回来。
+func injectTodoStatus(ctx context.Context, sink todoTextSink, status *string) {
+	todoStatus := functionTools.TodoStatusBar(ctx)
+	if sink != nil {
+		sink.SetTodoText(todoStatus)
+	}
+	if todoStatus != "" {
 		if *status != "" {
 			*status += "\n"
 		}

--- a/service/engine/tools/functions/todo.go
+++ b/service/engine/tools/functions/todo.go
@@ -77,10 +77,14 @@ func TodoStatusBar(ctx context.Context) string {
 	return renderTodoStatusBar(items)
 }
 
-// renderTodoStatusBar 把清单渲染成单行摘要：进行中的条目置顶（activeForm），
-// pending 逐条列出（content，超过 todoStatusBarMaxPending 折叠为计数），
-// completed 只显示计数。条目文本不截断，保持完整语义。全 completed 的清单
-// 会被 todo_write 自动清空，不会走到这里。
+// renderTodoStatusBar 把清单渲染成纵向摘要，每个元素独占一行：
+//   [TODO]
+//   ◐ 进行中（activeForm）
+//   ☐ 待办（content，超过 todoStatusBarMaxPending 折叠为计数）
+//   (N more · N done)
+// 条目文本不截断，保持完整语义。全 completed 的清单会被 todo_write 自动清空，
+// 不会走到这里。输出是带换行的多行文本，同一份喂给 [STATUS] prompt 尾部与
+// TodoBar（后者按行数占高）。
 func renderTodoStatusBar(items []todo.Item) string {
 	var inProgressText string
 	var pendingTexts []string
@@ -98,22 +102,26 @@ func renderTodoStatusBar(items []todo.Item) string {
 			completed++
 		}
 	}
-	var b strings.Builder
-	b.WriteString("[TODO] ")
+	lines := []string{"[TODO]"}
 	if inProgressText != "" {
-		b.WriteString("◐ " + inProgressText)
+		lines = append(lines, "◐ "+inProgressText)
 	}
-	if len(pendingTexts) > 0 {
-		if b.Len() > len("[TODO] ") {
-			b.WriteString(" | ")
-		}
-		b.WriteString("☐ " + strings.Join(pendingTexts, " | ☐ "))
-		if hidden := pending - len(pendingTexts); hidden > 0 {
-			b.WriteString(fmt.Sprintf(" (+%d more)", hidden))
-		}
+	for _, text := range pendingTexts {
+		lines = append(lines, "☐ "+text)
+	}
+	// 计数行：折叠数与完成数合并为一行，无计数时整行省略
+	var counts []string
+	if hidden := pending - len(pendingTexts); hidden > 0 {
+		counts = append(counts, fmt.Sprintf("%d more", hidden))
 	}
 	if completed > 0 {
-		b.WriteString(fmt.Sprintf(" (%d done)", completed))
+		counts = append(counts, fmt.Sprintf("%d done", completed))
 	}
-	return b.String()
+	if len(counts) > 0 {
+		lines = append(lines, "("+strings.Join(counts, " · ")+")")
+	}
+	if len(lines) == 1 {
+		return "" // 防御：items 非空时必有一种状态命中，正常不会走到
+	}
+	return strings.Join(lines, "\n")
 }

--- a/service/tui/Internal.go
+++ b/service/tui/Internal.go
@@ -1,34 +1,48 @@
 package tui
 
 import (
+	"HackerTeam/utils/pretty"
+	"slices"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
-	"HackerTeam/utils/pretty"
 )
 
-// ToggleHelpPage 切换帮助页显示/隐藏
+// toggleHelpPage 切换帮助页显示/隐藏。
+// 只会在 UI goroutine 上被调用（来自 inputArea / helpTable 的输入捕获器）。
 func (t *Tui) toggleHelpPage() {
-	if (*(*(*t).appLayout).helpTable).helpPageVisible {
-		(*t).app.SetRoot((*(*t).appLayout).pages, true)
-		(*t).app.SetFocus((*(*t).appLayout).inputArea)
-		(*(*(*t).appLayout).helpTable).helpPageVisible = false
+	ht := t.appLayout.helpTable
+	if ht.helpPageVisible {
+		t.app.SetRoot(t.appLayout.pages, true)
+		t.app.SetFocus(t.appLayout.inputArea)
+		ht.helpPageVisible = false
 	} else {
 		t.refreshhelpTable() // 每次打开时刷新，确保 skills 等动态项可见
 		flex := tview.NewFlex().SetDirection(tview.FlexRow)
 		flex.SetBackgroundColor(bg)
-		flex.AddItem((*(*(*t).appLayout).helpTable).h, 0, 1, true)
-		(*t).app.SetRoot(flex, true)
-		(*(*(*t).appLayout).helpTable).helpPageVisible = true
+		flex.AddItem(ht.h, 0, 1, true)
+		// SetRoot 内部会 SetFocus(root)，Flex.Focus 再委派给上面 AddItem 时 focus=true
+		// 的 table，所以 helpTable 的 Esc/Ctrl+K 捕获器能正常收到按键
+		t.app.SetRoot(flex, true)
+		ht.helpPageVisible = true
 	}
 }
 
 func (t *Tui) refreshhelpTable() {
-	(*(*t).appLayout).helpTable.h.Clear()
+	ht := t.appLayout.helpTable
+
+	// helpItems 可能被引擎 goroutine 的 AddHelpItems 并发追加（loadSkills 在 init 序列里跑），
+	// 先在锁内取快照再建单元格，不要持锁操作 table
+	ht.mu.Lock()
+	items := slices.Clone(ht.helpItems)
+	ht.mu.Unlock()
+
+	ht.h.Clear()
 
 	mainColor := tcell.GetColor(pretty.TuiMainText)
 	subColor := tcell.GetColor(pretty.TuiSubText)
 
-	for index, item := range (*(*(*t).appLayout).helpTable).helpItems {
+	for index, item := range items {
 		cmdCell := tview.NewTableCell(item.cmd).
 			SetTextColor(mainColor).
 			SetAlign(tview.AlignLeft).
@@ -39,13 +53,16 @@ func (t *Tui) refreshhelpTable() {
 			SetAlign(tview.AlignLeft).
 			SetExpansion(1)
 
-		(*(*t).appLayout).helpTable.h.SetCell(index, 0, cmdCell)
-		(*(*t).appLayout).helpTable.h.SetCell(index, 1, descCell)
+		ht.h.SetCell(index, 0, cmdCell)
+		ht.h.SetCell(index, 1, descCell)
 	}
 }
 
 func (t *Tui) defaultHelpItems() {
-	(*((*t).appLayout).helpTable).helpItems = []helpItem{
+	ht := t.appLayout.helpTable
+	ht.mu.Lock()
+	defer ht.mu.Unlock()
+	ht.helpItems = []helpItem{
 		{"/new", "开始新对话"},
 		{"/exit", "退出程序"},
 	}

--- a/service/tui/banner.go
+++ b/service/tui/banner.go
@@ -1,0 +1,275 @@
+package tui
+
+import (
+	"strings"
+
+	"HackerTeam/utils/pretty"
+	"github.com/rivo/tview"
+)
+
+// 启动横幅：banner 结构体描述内容（logo / 信息 / 面板三段），方法负责拼版。
+// 拼版方法不读 widget、宽度作参数传入，需要时可以直接对 banner 单测。
+
+const (
+	bannerLogoWidth = 12 // logo 点阵宽度，固定不可伸缩
+	bannerGap       = 1  // 段之间的间隔列
+
+	// bannerConfigMinWidth 信息列压缩下限，低于它就放弃三列改走堆叠
+	bannerConfigMinWidth = 24
+)
+
+// bannerLogo 5 行 H 字标，每行恰好 bannerLogoWidth 个 rune（█ 为 1 cell）。
+var bannerLogo = []string{
+	"  ██    ██  ",
+	" ██      ██ ",
+	" ██████████ ",
+	" ██      ██ ",
+	"  ██    ██  ",
+}
+
+// bannerLogoColors 与 bannerLogo 逐行对应，两端取 pretty 调色板常量，中间线性插值。
+var bannerLogoColors = []string{
+	"#4FC3F7", // = pretty.TColorSkyBlue
+	"#57C3F1",
+	"#5FC3EB",
+	"#67C3E5",
+	"#6FC3DF", // = pretty.TuiStatusHint
+}
+
+// banner 描述一条启动横幅：左 logo、中信息、右面板。
+// 信息行与面板行数相等（各 5 行），三块上下齐平，不需要垂直对齐逻辑。
+type banner struct {
+	logo      []string // 点阵行
+	logoColor []string // 逐行渐变色
+	info      []string // Engine 拼好的 "label value" 行
+	panel     bannerPanel
+}
+
+// bannerPanel 右栏键位提示面板，方框宽度由最长行测出（naturalWidth），加长提示不用改数字。
+type bannerPanel struct {
+	title string
+	lines []string
+}
+
+// defaultBannerPanel 默认面板。刻意保持 3 条：加边框正好 5 行，与 logo、信息列等高。
+var defaultBannerPanel = bannerPanel{
+	title: "getting started",
+	lines: []string{
+		"ctrl+k       slash commands",
+		"esc          interrupt this run",
+		"shift+enter  insert a newline",
+	},
+}
+
+// newBanner 用默认 logo 渐变与面板构造横幅。
+func newBanner(infoLines []string) *banner {
+	return &banner{
+		logo:      bannerLogo,
+		logoColor: bannerLogoColors,
+		info:      infoLines,
+		panel:     defaultBannerPanel,
+	}
+}
+
+// naturalWidth 面板自然宽度：最长行 + 1 前导空格 + 2 边框，不小于标题行所需。
+func (p bannerPanel) naturalWidth() int {
+	w := blockWidth(p.lines) + 3
+	if min := tview.TaggedStringWidth("─ "+p.title+" ") + 3; w < min {
+		w = min
+	}
+	return w
+}
+
+// render 画面板方框，每行恰好 panelW 列。
+func (p bannerPanel) render(panelW int) []string {
+	inner := panelW - 2
+
+	title := "─ " + p.title + " "
+	// 顶边框 = 1(╭) + title + dashes + 1(╮) = panelW，反推 dashes；clamp 仅防御
+	dashes := inner - tview.TaggedStringWidth(title)
+	if dashes < 0 {
+		dashes = 0
+	}
+
+	lines := make([]string, 0, len(p.lines)+2)
+	lines = append(lines, "╭"+title+strings.Repeat("─", dashes)+"╮")
+	for _, s := range p.lines {
+		lines = append(lines, "│"+fitWidth(" "+s, inner)+"│")
+	}
+	lines = append(lines, "╰"+strings.Repeat("─", inner)+"╯")
+	return lines
+}
+
+// totalWidth 三列完整版的自然总宽，降级判断与列宽计算共用。
+func (b *banner) totalWidth() int {
+	return bannerLogoWidth + bannerGap + blockWidth(b.info) + bannerGap + b.panel.naturalWidth()
+}
+
+// configWidth 信息列自然宽度 = 总宽 - logo - 面板 - 两个间隔列。
+func (b *banner) configWidth() int {
+	return b.totalWidth() - b.panel.naturalWidth() - bannerLogoWidth - 2*bannerGap
+}
+
+// compose 按可用宽度拼出横幅文本（不含首尾换行）。
+// 三段里只有信息列是弹性的（logo 是点阵艺术、面板是固定文案），降级顺序：
+// 放得下 → 三列零截断；放不下 → 压缩信息列保三列；压到下限以下 → 纵向堆叠。
+func (b *banner) compose(width int) string {
+	panelW := b.panel.naturalWidth()
+	if width >= b.totalWidth() {
+		return b.composeWide(b.configWidth(), panelW)
+	}
+	if avail := width - bannerLogoWidth - 2*bannerGap - panelW; avail >= bannerConfigMinWidth {
+		return b.composeWide(avail, panelW)
+	}
+	return b.composeStacked(width)
+}
+
+// composeWide 三列完整版：logo | 信息 | 面板，每行恰好三段之和列。
+func (b *banner) composeWide(configW, panelW int) string {
+	logo := b.coloredLogo()
+
+	info := make([]string, 0, len(b.info))
+	for _, line := range b.info {
+		// 整行一个颜色：Engine 传来的是已拼好的 "label value"，拆开上色不值得
+		info = append(info, pretty.TColoredText(pretty.TuiSubText, fitWidth(line, configW)))
+	}
+
+	panel := b.panel.render(panelW)
+
+	rows := len(logo)
+	if len(info) > rows {
+		rows = len(info)
+	}
+	if len(panel) > rows {
+		rows = len(panel)
+	}
+
+	var s strings.Builder
+	for i := 0; i < rows; i++ {
+		s.WriteString(lineAt(logo, i, bannerLogoWidth))
+		s.WriteString(strings.Repeat(" ", bannerGap))
+		s.WriteString(lineAt(info, i, configW))
+		s.WriteString(strings.Repeat(" ", bannerGap))
+		s.WriteString(lineAt(panel, i, panelW))
+		if i < rows-1 {
+			s.WriteString("\n")
+		}
+	}
+	return s.String()
+}
+
+// composeStacked 窄终端降级版：纵向堆叠、无方框，只截断不补齐。
+func (b *banner) composeStacked(width int) string {
+	// width <= 0 时不截断，交给 AgentMessage 的 SetWrap(true) 折行
+	clamp := func(s string) string {
+		if width <= 0 {
+			return tview.Escape(s)
+		}
+		return clampWidth(s, width)
+	}
+
+	var s strings.Builder
+	for i, row := range b.logo {
+		s.WriteString(pretty.TColoredText(b.logoColor[i], row))
+		s.WriteString("\n")
+	}
+	s.WriteString("\n")
+	for _, line := range b.info {
+		s.WriteString(pretty.TColoredText(pretty.TuiSubText, clamp(line)))
+		s.WriteString("\n")
+	}
+	s.WriteString("\n")
+	for _, line := range b.panel.lines {
+		s.WriteString(pretty.TColoredText(pretty.TuiSubText, clamp(line)))
+		s.WriteString("\n")
+	}
+	return strings.TrimRight(s.String(), "\n")
+}
+
+// coloredLogo 逐行套渐变色。
+func (b *banner) coloredLogo() []string {
+	logo := make([]string, len(b.logo))
+	for i, row := range b.logo {
+		logo[i] = pretty.TColoredText(b.logoColor[i], row)
+	}
+	return logo
+}
+
+// ---------- 字符串拼版辅助（通用，不绑定 banner） ----------
+
+// blockWidth 返回一组文本里最宽那行的显示宽度。必须量转义后的文本：
+// 字面 "[CN]" 的 TaggedStringWidth 是 0（被当颜色标签吞掉），转义后才是 4。
+func blockWidth(lines []string) int {
+	w := 0
+	for _, s := range lines {
+		if n := tview.TaggedStringWidth(tview.Escape(s)); n > w {
+			w = n
+		}
+	}
+	return w
+}
+
+// lineAt 取第 i 行，越界返回 w 个空格。
+func lineAt(lines []string, i, w int) string {
+	if i < len(lines) {
+		return lines[i]
+	}
+	return strings.Repeat(" ", w)
+}
+
+// fitWidth 转义 + 截断 + 补齐到恰好 w 列。
+func fitWidth(s string, w int) string {
+	s = clampWidth(s, w)
+	if pad := w - tview.TaggedStringWidth(s); pad > 0 {
+		s += strings.Repeat(" ", pad)
+	}
+	return s
+}
+
+// clampWidth 转义并截断到不超过 w 列。必须先 Escape 再度量（原因见 blockWidth）；
+// 末尾按 rune 硬切兜底，保证宽度不变量无条件成立。
+func clampWidth(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	s = tview.Escape(s)
+	if tview.TaggedStringWidth(s) > w {
+		s = truncateToWidth(s, w-1) + "…"
+	}
+	for tview.TaggedStringWidth(s) > w {
+		runes := []rune(s)
+		if len(runes) == 0 {
+			break
+		}
+		s = string(runes[:len(runes)-1])
+	}
+	return s
+}
+
+// truncateToWidth 从尾部逐 rune 回退到显示宽度不超过 w，入参必须已转义。
+func truncateToWidth(s string, w int) string {
+	runes := []rune(s)
+	for len(runes) > 0 && tview.TaggedStringWidth(string(runes)) > w {
+		runes = runes[:len(runes)-1]
+	}
+	return string(runes)
+}
+
+// ---------- TUI 接线 ----------
+
+// contentWidth 返回消息区当前内容宽度。GetInnerRect 无锁读布局字段，
+// 必须在 QueueUpdate 内调；用 QueueUpdate 而非 QueueUpdateDraw——只读值，不触发重绘。
+func (t *Tui) contentWidth() int {
+	var w int
+	t.app.QueueUpdate(func() {
+		_, _, w, _ = t.appLayout.agentMessage.GetInnerRect()
+	})
+	return w
+}
+
+// ShowStartupBanner 把启动横幅写进消息区，只在 Startup 那一轮调用一次。
+// 横幅是"死文本"：随对话滚动、resize 不重排，这是刻意的语义。
+func (t *Tui) ShowStartupBanner(infoLines []string) {
+	b := newBanner(infoLines)
+	t.PrintToMsgView("\n"+b.compose(t.contentWidth())+"\n\n\n", false)
+}

--- a/service/tui/tui.go
+++ b/service/tui/tui.go
@@ -1,64 +1,379 @@
 package tui
 
 import (
+	"strings"
+
 	"HackerTeam/utils/pretty"
 	"charm.land/glamour/v2"
-	"context"
 	"fmt"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
-	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
 // 定义颜色，配色统一来源于 pretty.TuiXxx 常量，确保界面风格统一且美观
 var (
-	bg                  tcell.Color = tcell.GetColor(pretty.TuiBg)          // 整体背景色
-	borderColor         tcell.Color = tcell.GetColor(pretty.TuiBorderColor) // 边框颜色
-	StatusBarBg         tcell.Color = tcell.GetColor(pretty.TuiStatusBarBg) // 标题栏背景色
-	inputAreaBg         tcell.Color = tcell.GetColor(pretty.TuiInputAreaBg) // 输入区背景色
-	DefaultStatusBarTip string      = pretty.TColoredText(pretty.TColorSkyBlue, "✦ « L’inspiration commence ici. » ✦")
+	bg          tcell.Color = tcell.GetColor(pretty.TuiBg)          // 整体背景色
+	borderColor tcell.Color = tcell.GetColor(pretty.TuiBorderColor) // 边框颜色
+	inputAreaBg tcell.Color = tcell.GetColor(pretty.TuiInputAreaBg) // 输入区背景色
+)
+
+const (
+	// drawInterval 重绘节流间隔。tview 只在 QueueUpdateDraw、按键/鼠标/resize 事件时重绘，
+	// 纯流式输出期间这些都不发生，所以由 drawLoop 按固定帧率驱动刷新。
+	drawInterval = 30 * time.Millisecond
+	// spinnerTicks 指示器每推进一帧占用多少个 drawInterval tick。3 × 30ms = 90ms/帧，
+	// 10 帧约 0.9s 转一圈。
+	spinnerTicks = 3
 )
 
 type Tui struct {
 	app       *tview.Application
 	appLayout *layout
-	InputChan chan string
+	inputChan chan string
+
+	// dirty 标记"内容已写入 widget 但尚未上屏"，由 drawLoop 消费。
+	// 写入走 QueueUpdate（只改 widget、不重绘）而不是 QueueUpdateDraw：后者每次调用都
+	// 阻塞等待一次完整全屏重绘，而 TextView.Draw 内部的 parseAhead 会把整个文本缓冲区
+	// 拷贝一遍（t.text.String()），流式输出下就是每 token O(n)、整体 O(n²)。
+	dirty    atomic.Bool
+	drawOnce sync.Once
+
+	// running 由引擎 goroutine 通过 SetAgentRunning 写、drawLoop 读。
+	// 指示器的实际外观切换全在 drawLoop 单线程里做，所以只有这一个字段需要跨 goroutine。
+	running atomic.Bool
+
+	// glamour renderer 构建时要解析一遍 style JSON，按宽度缓存复用
+	renderMu sync.Mutex
+	renderer *glamour.TermRenderer
+	renderW  int
 }
 
 type layout struct {
 	pages        *tview.Pages
-	statusBar    *tview.TextView
+	mainFlex     *tview.Flex // ResizeItem 要在父 Flex 上调，所以得存着
 	agentMessage *tview.TextView
+	todoBar      *todoBar
+	noticeBar    *noticeBar
+	indicator    *tview.TextView
 	inputArea    *tview.TextArea
 	helpTable    *helptable
 }
 type helptable struct {
 	h               *tview.Table
 	helpPageVisible bool
-	helpItems       []helpItem
+	// helpItems 由引擎 goroutine 写（AddHelpItems / ResetHelpItems），
+	// 由 UI goroutine 读（toggleHelpPage → refreshhelpTable），必须加锁
+	mu        sync.Mutex
+	helpItems []helpItem
 }
 type helpItem struct {
 	cmd  string
 	desc string
 }
 
-func (t *Tui) PrintToMsgView(content string, clear bool) {
-	(*t).app.QueueUpdateDraw(func() {
-		if clear == true {
-			(*(*t).appLayout).agentMessage.Clear()
+// ── 输入区左侧的运行指示器 ─────────────────────────────
+//
+// 做成独立 widget 而不是 TextArea 的 label：TextArea.SetLabel 是无锁写字段
+// （textarea.go:792），由 UI 线程在 Draw 中读取，跨 goroutine 调用是数据竞争，
+// 每帧都得包一层 QueueUpdate；而 TextView.SetText 自带锁，drawLoop 可以直接调。
+
+const indicatorWidth = 2
+
+var (
+	// 空闲态。indicator 开了 SetDynamicColors，所以可以带 tview 颜色标签。
+	// 用 TuiSubText 而不是 tview 默认的 label 颜色——后者是 ColorYellow。
+	idleIndicator = pretty.TColoredText(pretty.TuiSubText, "> ")
+	// 盲文 10 帧，每个都是 1 cell 宽（已实测），加一个空格正好 indicatorWidth 列
+	spinnerFrames = []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+)
+
+// spinnerIndicator 渲染运行态的第 frame 帧。frame 由 drawLoop 单调递增传入，此处取模回绕。
+func spinnerIndicator(frame int) string {
+	return pretty.TColoredText(pretty.TColorLightMagenta,
+		string(spinnerFrames[frame%len(spinnerFrames)])+" ")
+}
+
+// ── 输入框上方的两个 bar ─────────────────────────────
+//
+// TodoBar：纵向清单栏，每个任务一行，有清单时占 N 行、无清单时塌成 0 行。
+// NoticeBar：固定 1 行，承载瞬时通知与常驻键位提示，永不塌陷（hint 常驻）。
+
+const (
+	// noticeTTL 临时通知的停留时长。到期后 NoticeBar 自动回落到兜底提示。
+	noticeTTL = 4 * time.Second
+	// minMessageRows 消息区无论如何至少保留的行数。矮终端下用它钳制 TodoBar 高度：
+	// Flex 的 distSize = height - 所有 fixedSize 之和且不做钳制，Box.SetRect 也原样
+	// 存负高度，而 pos += size 用原始值 → 不钳制会让 AgentMessage 拿到负高度、
+	// pos 倒退、下方三个 item 全部画错行并在屏幕底部留残影。
+	minMessageRows = 3
+)
+
+// NoticeBar 的常驻兜底提示。全小写英文，沿用被删除的 InputHint 的 [gray::d] 暗灰样式。
+// esc to interrupt 只在运行态出现——ESC 中断仅在 agent 运行期间有效，平时显示它是噪音。
+const (
+	hintIdle    = `[gray::d]ctrl+k for help[-:-:-]`
+	hintRunning = `[gray::d]esc to interrupt · ctrl+k for help[-:-:-]`
+)
+
+// noticeBar 输入框上方的单行通知栏。notice 与 hint 二选一，一次只显示一种。
+type noticeBar struct {
+	view *tview.TextView
+
+	// 槽位由引擎 goroutine 写（setNotice），由 drawLoop 读写（render 里清理过期
+	// 通知），是真·多写入方，必须加锁。
+	// 注意与 indicator 的区别：indicator 只有 drawLoop 一个写入方，所以不需要锁。
+	mu          sync.Mutex
+	notice      string    // 临时通知（已带颜色标签，调用方负责）
+	noticeUntil time.Time // 过期时间
+}
+
+func (b *noticeBar) setNotice(msg string, ttl time.Duration) {
+	b.mu.Lock()
+	b.notice = msg
+	b.noticeUntil = time.Now().Add(ttl)
+	b.mu.Unlock()
+}
+
+// render 未过期的 notice 优先，否则回落到 hint（按 running 二选一）。
+// running 由调用方（drawLoop）传入，它本来就已经读过这个原子标志。
+func (b *noticeBar) render(running bool) string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.notice != "" {
+		if time.Now().Before(b.noticeUntil) {
+			return b.notice
 		}
-		fmt.Fprint((*(*t).appLayout).agentMessage, content)
-		(*(*t).appLayout).agentMessage.ScrollToEnd()
+		b.notice = "" // 过期即清，避免每帧反复比对一个死字符串
+	}
+	if running {
+		return hintRunning
+	}
+	return hintIdle
+}
+
+// todoBar 输入框上方的纵向清单栏（每个任务一行）。有清单时占 N 行，无清单时塌成 0 行。
+type todoBar struct {
+	view *tview.TextView
+
+	// text 是引擎 goroutine 推来的原始多行纯文本（每个任务一行，未转义）。转义、
+	// 着色、SetText、ResizeItem 全在 drawLoop 里做，保持"widget 写入单线程"。
+	// 引擎写、drawLoop 读，是真·多写入方，必须加锁。
+	mu   sync.Mutex
+	text string
+}
+
+func (b *todoBar) store(text string) {
+	b.mu.Lock()
+	b.text = text
+	b.mu.Unlock()
+}
+
+func (b *todoBar) current() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.text
+}
+
+// SetTodoText 更新 TodoBar 的清单文本，传空串则整栏塌成 0 行。
+// 当前收到的是多行文本（functionTools.TodoStatusBar 的输出，每个任务一行）。
+// ⚠️ text 是**来自框架/LLM 的纯文本**（以 "[TODO] " 开头，且条目正文由 LLM 撰写），
+// 转义与着色由 drawLoop 负责——与 ShowNotice 的契约相反（那个收的是受信 markup，
+// 转义会破坏颜色标签）。
+// 由 agent 包的 BeforeModel callback 在每次 LLM hop 推送，可从任意 goroutine 调用。
+func (t *Tui) SetTodoText(text string) {
+	t.appLayout.todoBar.store(text)
+	t.markDirty()
+}
+
+// drawState 是 drawLoop 的私有状态。只被 drawLoop 这一个 goroutine 读写，
+// 不是共享状态，因此无需同步（刻意不做成 Tui 的字段，避免误导后人以为要加锁）。
+type drawState struct {
+	showingRunning bool   // indicator 当前显示的是否为运行态
+	spinTick       int    // spinner 帧推进计数
+	shownTodo      string // TodoBar 上一帧的原始文本
+	shownNotice    string // NoticeBar 上一帧的渲染结果
+}
+
+// startDrawLoop 启动固定帧率的重绘循环，只启动一次。
+// 它是"重绘节流 + 动画时钟"的多重身份：除了按 dirty 标志节流重绘，还独占驱动
+// 运行指示器动画与两个 bar 的内容刷新。所有 widget 写入因此都是单线程的，
+// 配合 TextView.SetText 自带锁，既不需要额外同步也不需要为每件事单起 ticker。
+func (t *Tui) startDrawLoop() {
+	t.drawOnce.Do(func() {
+		go func() {
+			ticker := time.NewTicker(drawInterval)
+			defer ticker.Stop()
+
+			st := &drawState{}
+			for range ticker.C {
+				running := t.running.Load()
+				t.tickIndicator(running, st)
+				t.tickTodoBar(st)
+				t.tickNoticeBar(running, st)
+				// 没有新内容就不重绘，空闲时不产生任何 CPU 开销
+				if t.dirty.CompareAndSwap(true, false) {
+					t.app.Draw()
+				}
+			}
+		}()
 	})
 }
 
-func (t *Tui) ReadInputAreaPromptWithEnter() {
-	(*t).app.QueueUpdateDraw(func() {
-		(*t).app.SetFocus((*(*t).appLayout).inputArea)
+// tickIndicator 推进运行指示器。
+// 用 if/else-if 而非 switch —— 项目风格要求，不要改回 switch。
+func (t *Tui) tickIndicator(running bool, st *drawState) {
+	if running != st.showingRunning { // 状态翻转：立刻换外观，帧计数归零
+		st.showingRunning = running
+		st.spinTick = 0
+		if running {
+			t.setIndicator(spinnerIndicator(0))
+		} else {
+			t.setIndicator(idleIndicator)
+		}
+	} else if running { // 持续运行：每 spinnerTicks 个 tick 推进一帧
+		st.spinTick++
+		if st.spinTick%spinnerTicks == 0 {
+			t.setIndicator(spinnerIndicator(st.spinTick / spinnerTicks))
+		}
+	}
+}
+
+// tickNoticeBar 刷新通知栏。TTL 到期、通知到达、running 翻转三件事全走这一条路径，
+// 因此不需要任何事件驱动的机制。
+func (t *Tui) tickNoticeBar(running bool, st *drawState) {
+	nb := t.appLayout.noticeBar
+	if s := nb.render(running); s != st.shownNotice {
+		st.shownNotice = s
+		nb.view.SetText(s) // TextView.SetText 自带锁，无需 QueueUpdate
+		t.dirty.Store(true)
+	}
+}
+
+// tickTodoBar 刷新清单栏的内容与高度（0 到 N 行，每个任务一行）。
+//
+// 高度钳制的原因：Flex 的 distSize = height - 所有 fixedSize 之和且不做钳制，
+// Box.SetRect 也原样存负高度，而 pos += size 用原始值。终端高度不足时 distSize
+// 变负 → AgentMessage 拿到负高度 → pos 倒退 → 下方三个 item 全部画错行、
+// 屏幕底部留未绘制残影。行数超过 max 时压到 max（顶部行可见，其余被挡住）；
+// max 不足 1 时塌成 0 行。
+//
+// 多行后必须 ScrollToBeginning()：SetText 只调 resetIndex()，不清
+// lineOffset/trackEnd，而 NewTextView() 默认 scrollable=true，滚轮下滚会把
+// trackEnd 置真、导致视图永久卡在底部。SetScrollable(false) 不是解法
+// （它会顺手把 trackEnd 设成 true，直接底部锚定）。
+func (t *Tui) tickTodoBar(st *drawState) {
+	tb := t.appLayout.todoBar
+	text := tb.current()
+	if text == st.shownTodo {
+		return
+	}
+	st.shownTodo = text
+
+	rendered := ""
+	n := 0
+	if text != "" {
+		rendered = renderTodoLines(text)
+		n = strings.Count(text, "\n") + 1
+	}
+
+	// ResizeItem 无锁写 FixedSize/Proportion、GetInnerRect 无锁读布局字段，两者都
+	// 由 UI 线程在 Draw 中使用，所以必须一起放进 QueueUpdate（那里就是 UI 线程）。
+	t.app.QueueUpdate(func() {
+		_, _, _, total := t.appLayout.mainFlex.GetInnerRect()
+		// NoticeBar 与 InputRow 各占 1 行，消息区至少留 minMessageRows 行
+		if max := total - 2 - minMessageRows; n > max {
+			n = max
+		}
+		if n < 0 {
+			n = 0
+		}
+		tb.view.SetText(rendered)
+		tb.view.ScrollToBeginning()
+		// proportion 必须是 0：给 1 会让 TodoBar 与 AgentMessage 平分剩余空间
+		t.appLayout.mainFlex.ResizeItem(tb.view, n, 0)
+	})
+	t.dirty.Store(true)
+}
+
+// renderTodoLines 把 TodoBar 的多行纯文本转义并逐行上色：
+// [TODO] 头行与 (N done) 计数行暗灰、◐ 进行中青色、☐ 待办正文色。
+// 必须逐行先 tview.Escape 再包颜色标签："[TODO]" 会被 tview 当成前景色名整个吞掉
+// （实测 "[TODO] x" 的 TaggedStringWidth 是 2 而非 8），条目正文由 LLM 撰写、
+// 可能含 ASCII 方括号。Escape 与着色都不改变行数，高度计算不受影响。
+func renderTodoLines(text string) string {
+	colorOf := func(line string) string {
+		switch {
+		case strings.HasPrefix(line, "◐ "):
+			return pretty.TColorCyan
+		case strings.HasPrefix(line, "☐ "):
+			return pretty.TuiMainText
+		default: // [TODO] 头行、计数行
+			return pretty.TuiSubText
+		}
+	}
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		lines[i] = pretty.TColoredText(colorOf(line), tview.Escape(line))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ShowNotice 在 NoticeBar 显示一条临时通知，noticeTTL 后自动回落到兜底提示。
+// ⚠️ msg 必须是**已带 tview 颜色标签的受信 markup**（用 pretty.TBarXxx 系列生成），
+// 本方法不做转义——转义会破坏颜色标签。与 SetTodoText 的契约相反。
+// 只取 mutex 写字段、不走 QueueUpdate，因此在 app.Run() 启动前调用也不会阻塞。
+// 这比被它替换掉的 ShowSuccessInMsgView 更好：后者经 PrintToMsgView → QueueUpdate，
+// 会在事件循环启动前阻塞住 init 序列。
+func (t *Tui) ShowNotice(msg string) {
+	t.appLayout.noticeBar.setNotice(msg, noticeTTL)
+	t.markDirty()
+}
+
+// setIndicator 更新指示器文本并请求重绘。只允许 drawLoop 调用。
+// TextView.SetText 自带锁，可以直接从本 goroutine 调，不需要 QueueUpdate。
+func (t *Tui) setIndicator(s string) {
+	t.appLayout.indicator.SetText(s)
+	t.dirty.Store(true)
+}
+
+// SetAgentRunning 标记 agent 是否正在运行。只写一个原子标志，可从任意 goroutine 调用、
+// 不阻塞；指示器的实际切换由 drawLoop 在下一帧完成（最多 drawInterval 延迟）。
+func (t *Tui) SetAgentRunning(running bool) {
+	t.running.Store(running)
+}
+
+// markDirty 标记需要重绘。必须在 widget 写入完成之后调用：QueueUpdate 是阻塞的，
+// 返回时内容已经落地，这样 drawLoop 的下一帧才画得到它。反过来（先标记后写入）
+// 会出现"这一帧把标记消费掉了、内容却还没写进去"，导致最后一批文本永不上屏。
+func (t *Tui) markDirty() {
+	t.startDrawLoop()
+	t.dirty.Store(true)
+}
+
+func (t *Tui) PrintToMsgView(content string, clear bool) {
+	t.app.QueueUpdate(func() {
+		if clear {
+			t.appLayout.agentMessage.Clear()
+		}
+		fmt.Fprint(t.appLayout.agentMessage, content)
+	})
+	// 这里不调 ScrollToEnd()。它会把 TextView 的 trackEnd 强行置回 true，于是用户在
+	// 流式输出期间往上翻滚查看历史时，下一个 token 就把视图弹回底部。trackEnd 本身就是
+	// "是否在底部、是否该跟随"的标记，tview 自己维护（滚轮上翻置 false、翻回底部置 true），
+	// 初始值在 GetTuiService 里开一次即可。
+	t.markDirty()
+}
+
+func (t *Tui) ListenUserInput() chan string {
+	t.app.QueueUpdateDraw(func() {
+		t.app.SetFocus(t.appLayout.inputArea)
 
 		//注册一个输入捕获器，每次用户在输入框敲击键盘时都会触发
-		(*(*t).appLayout).inputArea.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		t.appLayout.inputArea.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 			// Ctrl+K 切换帮助页
 			if event.Key() == tcell.KeyCtrlK {
 				t.toggleHelpPage()
@@ -66,81 +381,31 @@ func (t *Tui) ReadInputAreaPromptWithEnter() {
 			}
 
 			// Enter 提交输入
-			// ModNone = 0，无任何修饰键（Ctrl/Shift/Alt 均未按下），即裸按 Enter
+			// ModNone = 0，无任何修饰键（Ctrl/Shift/Alt 均未按下），即裸按 Enter。
+			// Shift+Enter 落到函数末尾的 return event，由 TextArea 插入换行（手动多行输入）。
 			// bracketed paste 保证粘贴里的 \n 走 PasteEvent 通道，不会产生 KeyEnter 事件
 			if event.Key() == tcell.KeyEnter && event.Modifiers() == tcell.ModNone {
 
 				//获取输入文本
-				text := (*(*t).appLayout).inputArea.GetText()
-				// 发送输入文本到 InputChan。default 分支：对端（引擎循环）未在监听时
+				text := t.appLayout.inputArea.GetText()
+				// 发送输入文本到 inputChan。default 分支：对端（引擎循环）未在监听时
 				// （如自动 turn 期间）不投递，避免 unbuffered send 阻塞 tview 事件循环
 				// 导致 UI 卡死。注意：只有投递成功才清空输入框，default 分支保留文本，
 				// 用户输入不丢失。
 				select {
-				case (*t).InputChan <- text:
-					(*(*t).appLayout).inputArea.SetText("", false)
+				case t.inputChan <- text:
+					t.appLayout.inputArea.SetText("", false)
 				default:
 				}
 				return nil //Enter事件不捕获
-			}
-
-			// Shift+Enter 插入换行（手动多行输入）
-			if event.Key() == tcell.KeyEnter && event.Modifiers() == tcell.ModShift {
-				return event
 			}
 
 			//传递事件给 TextArea 默认处理（插入字符、换行等）
 			return event
 		})
 	})
+	return t.inputChan
 
-}
-
-func (t *Tui) InputChannel() chan string {
-	return (*t).InputChan
-}
-
-func (t *Tui) StatusBarScrollingTip(ctx context.Context, tip string, TColor string) {
-	char := strings.Split(tip, "")
-	dynamicWords := []string{}
-	increaseWords := []string{}
-	//逐渐增加字符，拼接成新的字符串，写入dynamicWords切片中
-	for i := 0; i < len(char); i++ {
-		if i == 0 {
-			increaseWords = append(increaseWords, char[i])
-		} else {
-			increaseWords = append(increaseWords, increaseWords[i-1]+char[i])
-		}
-	}
-
-	decreaseWords := []string{}
-	for i := 0; i < len(char); i++ {
-		char[i] = " "
-		decreaseWords = append(decreaseWords, strings.Join(char, ""))
-	}
-	dynamicWords = append(dynamicWords, increaseWords...)
-	dynamicWords = append(dynamicWords, decreaseWords...)
-	for {
-		for _, word := range dynamicWords {
-
-			select {
-			case <-ctx.Done():
-
-				(*t).app.QueueUpdateDraw(func() {
-					(*(*t).appLayout).statusBar.Clear()
-					fmt.Fprint((*(*t).appLayout).statusBar, pretty.TColoredText(pretty.TColorGreen, DefaultStatusBarTip))
-				})
-				return
-			default:
-			}
-
-			time.Sleep(80 * time.Millisecond)
-			(*t).app.QueueUpdateDraw(func() {
-				(*(*t).appLayout).statusBar.Clear()
-				fmt.Fprint((*(*t).appLayout).statusBar, pretty.TColoredText(TColor, word))
-			})
-		}
-	}
 }
 
 func (t *Tui) SetAppFuncTriggerWithEsc(f func()) {
@@ -160,74 +425,87 @@ func (t *Tui) ClearAppFuncTrigger() {
 		(*t).app.SetInputCapture(nil)
 	})
 }
-func (t *Tui) StatusBarUserTip(s string) {
-	(*t).app.QueueUpdateDraw(func() {
-		(*(*t).appLayout).statusBar.Clear()
-		fmt.Fprint((*(*t).appLayout).statusBar, s)
-	})
-}
-func (t *Tui) ShowErrorInMsgViewAndExit(errmsg string) {
-	done := make(chan struct{})
-	t.PrintToMsgView(errmsg, false)
-	(*t).app.QueueUpdateDraw(func() {
+
+// showMsgAndExit 打印一条消息并结束程序。waitForKey=true 时等用户按任意键再退出。
+//
+// 末尾的 select{} 是故意的，不要改成"由回调 close(chan) 然后返回"：
+//   - 调用方（引擎 init 序列）打完致命错误后并没有 return，一旦这里返回，引擎 goroutine
+//     会带着未初始化的状态（如 nil memory service）继续往下跑，最后在别处 panic。
+//   - 也不能在下面的回调里直接 os.Exit：screen.Fini() 是在 app.Run() 的返回路径上调的，
+//     从回调硬退出会跳过它，终端会留在 alt-screen + raw mode，退出后用户的 shell 是坏的。
+//
+// 现在的收尾链路是：app.Stop() → tui.Run() 返回 → tview 复原终端 → main() 返回 → 进程退出。
+func (t *Tui) showMsgAndExit(msg string, waitForKey bool) {
+	t.PrintToMsgView(msg, false)
+	// 强制刷一帧：PrintToMsgView 现在只写入不重绘，不显式 Draw 的话退出信息
+	// 可能还没上屏 app 就 Stop 了。
+	t.app.Draw()
+	t.app.QueueUpdate(func() {
+		if !waitForKey {
+			t.app.Stop()
+			return
+		}
 		//只要有按键就退出程序
-		(*t).app.SetFocus((*(*t).appLayout).agentMessage)
-		(*(*t).appLayout).agentMessage.SetInputCapture(
+		t.app.SetFocus(t.appLayout.agentMessage)
+		t.appLayout.agentMessage.SetInputCapture(
 			func(event *tcell.EventKey) *tcell.EventKey {
-				(*t).app.Stop()
+				t.app.Stop()
 				return nil
 			})
 	})
-	<-done
+	select {}
 }
 
-func (t *Tui) ShowSuccessInMsgView(sussessmsg string) {
-	t.PrintToMsgView(pretty.TSuccess(sussessmsg), false)
+func (t *Tui) ShowErrorInMsgViewAndExit(errmsg string) {
+	t.showMsgAndExit(errmsg, true)
 }
+
 func (t *Tui) ShowSuccessInMsgViewAndExit(sussessmsg string) {
-	done := make(chan struct{})
-	t.PrintToMsgView(pretty.TSuccess(sussessmsg), false)
-	(*t).app.QueueUpdateDraw(func() {
-		//只要有按键就退出程序
-		(*t).app.SetFocus((*(*t).appLayout).agentMessage)
-		(*(*t).appLayout).agentMessage.SetInputCapture(
-			func(event *tcell.EventKey) *tcell.EventKey {
-				(*t).app.Stop()
-				return nil
-			})
-	})
-	<-done
+	t.showMsgAndExit(pretty.TSuccess(sussessmsg), true)
 }
 
 func (t *Tui) ShowMsgAndExitNoTrigger(msg string) {
-	done := make(chan struct{})
-	t.PrintToMsgView(msg, false)
-	(*t).app.QueueUpdateDraw(func() {
-		(*t).app.Stop()
-
-	})
-	<-done
+	t.showMsgAndExit(msg, false)
 }
+
 func (t *Tui) AddHelpItems(items []map[string]string) {
+	ht := t.appLayout.helpTable
+	ht.mu.Lock()
+	defer ht.mu.Unlock()
 	for _, i := range items {
 		for k, v := range i {
-			h := helpItem{
-				cmd:  k,
-				desc: v,
-			}
-			(*((*t).appLayout).helpTable).helpItems = append((*((*t).appLayout).helpTable).helpItems, h)
+			ht.helpItems = append(ht.helpItems, helpItem{cmd: k, desc: v})
 		}
 	}
 }
+
 func (t *Tui) ResetHelpItems() {
 	t.defaultHelpItems()
 }
-func (t *Tui) newGlamourRender() *glamour.TermRenderer {
-	_, _, w, _ := (*(*t).appLayout).agentMessage.GetInnerRect()
+
+// RenderMarkdown 用 glamour 渲染 markdown。
+func (t *Tui) RenderMarkdown(in string) (string, error) {
+	r, err := t.glamourRenderer()
+	if err != nil {
+		return "", err
+	}
+	return r.Render(in)
+}
+
+// glamourRenderer 返回按当前消息区宽度缓存的 renderer，宽度变化时才重建。
+func (t *Tui) glamourRenderer() (*glamour.TermRenderer, error) {
+	// 宽度读取与竞争规避见 banner.go 里 contentWidth 的注释
+	w := t.contentWidth()
 	if w < 40 {
 		w = 80
 	}
-	r, _ := glamour.NewTermRenderer(
+
+	t.renderMu.Lock()
+	defer t.renderMu.Unlock()
+	if t.renderer != nil && t.renderW == w {
+		return t.renderer, nil
+	}
+	r, err := glamour.NewTermRenderer(
 		glamour.WithStandardStyle("dark"),
 		glamour.WithWordWrap(w),
 		glamour.WithStylesFromJSONBytes([]byte(`{
@@ -236,11 +514,13 @@ func (t *Tui) newGlamourRender() *glamour.TermRenderer {
 			}
 		}`)),
 	)
-	return r
+	if err != nil {
+		return nil, err
+	}
+	t.renderer, t.renderW = r, w
+	return r, nil
 }
-func (t *Tui) RenderMarkdown(in string) (string, error) {
-	return t.newGlamourRender().Render(in)
-}
+
 func (t *Tui) Run() {
 	err := (*t).app.Run()
 	if err != nil {
@@ -248,12 +528,6 @@ func (t *Tui) Run() {
 	}
 }
 func GetTuiService() *Tui {
-	//设置标题状态栏
-	StatusBar := tview.NewTextView()
-	StatusBar.SetDynamicColors(true).SetWrap(false).SetText(DefaultStatusBarTip)
-	StatusBar.SetTextAlign(tview.AlignCenter)
-	StatusBar.SetBackgroundColor(StatusBarBg)
-
 	//设置Agent消息显示区
 	AgentMessage := tview.NewTextView().
 		SetDynamicColors(true). // 启用颜色
@@ -261,35 +535,60 @@ func GetTuiService() *Tui {
 		SetWrap(true)
 
 	AgentMessage.SetBackgroundColor(bg) // 设置背景颜色
+	// 打开"跟随底部"。SetScrollable(true) 不会设置 trackEnd（只有传 false 才会），
+	// 所以必须显式开一次，否则视图会永远停在顶部、完全不跟随新输出。
+	// 之后用户在底部就继续跟随、往上翻就不打扰，全部由 tview 自己维护。
+	AgentMessage.ScrollToEnd()
 
-	//设置底部输入区
-	InputArea := tview.NewTextArea().
-		SetLabel(`⇒ `).
-		SetWrap(true)
+	// 输入区左侧的运行指示器：空闲显示 ">"，agent 运行中显示盲文 spinner，由 drawLoop 驱动。
+	// 背景必须是 inputAreaBg：这个位置原本在 TextArea 内部、底色就是 inputAreaBg，
+	// 不设的话会继承 InputRow 的 bg，左边出现一块 2 格的色差。
+	Indicator := tview.NewTextView().
+		SetDynamicColors(true).
+		SetWrap(false).
+		SetText(idleIndicator)
+	Indicator.SetBackgroundColor(inputAreaBg)
+
+	//设置底部输入区（不再有 label，提示符由 Indicator 承担）
+	InputArea := tview.NewTextArea().SetWrap(true)
 	InputArea.SetBackgroundColor(inputAreaBg)
 	InputArea.SetTextStyle(tcell.StyleDefault.
 		Background(inputAreaBg).                        // 输入区背景色
 		Foreground(tcell.GetColor(pretty.TuiMainText))) // 文字颜色
 
-	// 输入区右侧提示
-	InputHint := tview.NewTextView().
+	// 消息区与通知栏之间的清单栏：纵向，每个任务一行，有清单时占 N 行、无清单时塌成 0 行。
+	// 背景用 bg（不是 inputAreaBg）：它是参考信息，视觉上应融入消息区，
+	// 与下方"控制区"（NoticeBar + InputRow）区分开。
+	// 高度由 drawLoop 通过 mainFlex.ResizeItem 动态设置，初始 0 行。
+	// 不要对它调 SetScrollable(false)——那会把 trackEnd 置真（见 tickTodoBar 注释）。
+	TodoBar := tview.NewTextView().
+		SetDynamicColors(true).
+		SetWrap(false)
+	TodoBar.SetBackgroundColor(bg)
+
+	// 输入框上方的通知栏：瞬时通知 + 常驻键位提示，固定 1 行、永不塌陷。
+	// 不设背景色，继承 MainFlex 的 bg——让它融入消息区而不是和 InputRow 连成一块。
+	// 内容全部带颜色标签，所以不需要 SetTextColor。
+	// 内容靠右：与原来 InputHint 在 InputRow 右侧的位置一致，视线落点不变。
+	// 注意通知与兜底提示共用这一个 widget，所以两者都靠右。
+	NoticeBar := tview.NewTextView().
 		SetDynamicColors(true).
 		SetWrap(false).
-		SetTextAlign(tview.AlignRight)
-	InputHint.SetBackgroundColor(bg)
-	InputHint.SetText("[gray::d]Ctrl+K 帮助[-:-:-]")
+		SetTextAlign(tview.AlignRight).
+		SetText(hintIdle)
 
 	InputRow := tview.NewFlex().SetDirection(tview.FlexColumn)
 	InputRow.SetBackgroundColor(bg)
+	InputRow.AddItem(Indicator, indicatorWidth, 0, false) // 左侧运行指示器
 	InputRow.AddItem(InputArea, 0, 1, true)
-	InputRow.AddItem(InputHint, 15, 0, false)
 
 	//设置整体布局
 	MainFlex := tview.NewFlex().SetDirection(tview.FlexRow)
 	MainFlex.SetBackgroundColor(bg)
-	MainFlex.AddItem(StatusBar, 1, 0, false)    // 顶部的状态栏占1行
 	MainFlex.AddItem(AgentMessage, 0, 1, false) // Agent消息区占剩余空间
-	MainFlex.AddItem(InputRow, 1, 0, true)      // 底部的输入区+提示
+	MainFlex.AddItem(TodoBar, 0, 0, false)      // 清单栏，初始 0 行，由 ResizeItem 动态调整
+	MainFlex.AddItem(NoticeBar, 1, 0, false)    // 通知栏，固定 1 行、永不塌陷
+	MainFlex.AddItem(InputRow, 1, 0, true)      // 底部的输入区
 
 	HelpTable := tview.NewTable()
 	HelpTable.SetBackgroundColor(bg)
@@ -314,8 +613,11 @@ func GetTuiService() *Tui {
 		app: app,
 		appLayout: &layout{
 			pages:        pages,
-			statusBar:    StatusBar,
+			mainFlex:     MainFlex,
 			agentMessage: AgentMessage,
+			todoBar:      &todoBar{view: TodoBar},
+			noticeBar:    &noticeBar{view: NoticeBar},
+			indicator:    Indicator,
 			inputArea:    InputArea,
 			helpTable: &helptable{
 				h:               HelpTable,
@@ -323,7 +625,7 @@ func GetTuiService() *Tui {
 				helpPageVisible: false,
 			},
 		},
-		InputChan: make(chan string),
+		inputChan: make(chan string),
 	}
 
 	(*(*(*tui).appLayout).helpTable).h.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {

--- a/utils/pretty/pretty.go
+++ b/utils/pretty/pretty.go
@@ -78,10 +78,9 @@ const (
 
 // ========== TUI 界面配色（GitHub 深色模式 + 深空蓝调）==========
 const (
-	TuiBg          = "#0F1115" // 整体背景色
+	TuiBg          = "#000000" // 整体背景色
 	TuiPanelBg     = "#151821" // 面板/侧边栏背景色
 	TuiBorderColor = "#2A2F3A" // 边框颜色
-	TuiStatusBarBg = "#151821" // 状态栏背景色
 	TuiInputAreaBg = "#151821" // 输入区背景色
 	TuiSplitLine   = "#4A5060" // 分割线颜色
 	TuiMainText    = "#C9D1D9" // 主文本颜色
@@ -456,16 +455,26 @@ func ErrorFWithExit(format string, args ...interface{}) {
 //
 // 设计规范:
 //   颜色语义: green=成功/正向  red=错误  yellow=警告/推理  cyan=用户/信息  magenta=工具
-//   符号规范: ✓成功 ✗错误 ⚠警告 ▶用户 ⚙工具 ◈状态
+//   符号规范: 系统消息（下面「状态消息」与「生命周期」两节）**不带任何符号**，语义完全
+//             由颜色承载。符号只用于对话内容的视觉标记，当前实际在用的是：
+//             ▶用户输入  ●工具行/非流式正文前缀  ↪工具结果  ⮡工具调用  »«推理区块
 //   布局规范: 状态消息前空行分隔，推理/工具用边框包裹
 
 const thinLine = "────────────────────────────────────────"
 
 // ── 状态消息 ─────────────────────────────────
+//
+// 本节与下面的「生命周期」节都属于"系统消息"：不带任何装饰符号，语义完全由颜色承载
+// （红=错误、黄=警告/中断、绿=成功、青=信息）。原来的 ✗ ✓ ⚠ ◈ 前缀已移除，
+// 同时去掉了 ::b —— 原来只有符号是粗体、正文是常规字重，符号没了就不需要粗体。
+// 新增本节的 helper 必须遵守此规则。
+//
+// 不在此列、符号必须保留的是对话内容的视觉标记：TUserInput 的 ▶、
+// 工具区块的 ● ↪ ⮡、推理区块的 » «、正文区块的 ●。
 
 // TError TUI 错误信息
 func TError(text string) string {
-	return fmt.Sprintf("\n[red::b]✗ [-:-:-]%s\n", text)
+	return fmt.Sprintf("\n[red]%s[-:-:-]\n", text)
 }
 
 // TErrorF TUI 格式化错误信息
@@ -475,7 +484,7 @@ func TErrorF(format string, args ...interface{}) string {
 
 // TSuccess TUI 成功信息
 func TSuccess(text string) string {
-	return fmt.Sprintf("\n[green::b]✓ [-:-:-]%s\n", text)
+	return fmt.Sprintf("\n[green]%s[-:-:-]\n", text)
 }
 
 // TSuccessF TUI 格式化成功信息
@@ -485,7 +494,7 @@ func TSuccessF(format string, args ...interface{}) string {
 
 // TWarning TUI 警告信息
 func TWarning(text string) string {
-	return fmt.Sprintf("\n[yellow::b]⚠ [-:-:-]%s\n", text)
+	return fmt.Sprintf("\n[yellow]%s[-:-:-]\n", text)
 }
 
 // TWarningF TUI 格式化警告信息
@@ -494,36 +503,57 @@ func TWarningF(format string, args ...interface{}) string {
 }
 
 // ── 生命周期 ─────────────────────────────────
+//
+// 同属"系统消息"，规则见上面「状态消息」节的注释：不带装饰符号，语义由颜色承载。
 
 // TWelcome TUI 欢迎/提示信息
 func TWelcome(text string) string {
-	return fmt.Sprintf("\n[green::b]◈ [-:-:-]%s\n", text)
+	return fmt.Sprintf("\n[green]%s[-:-:-]\n", text)
 }
 
 // TReady TUI 启动完成信息
 func TReady(name string) string {
-	return fmt.Sprintf("\n[green::b]✓ [-:-:-]%s 就绪\n", name)
+	return fmt.Sprintf("\n[green]%s 就绪[-:-:-]\n", name)
 }
 
 // TExit TUI 退出/结束信息
 func TExit(text string) string {
-	return fmt.Sprintf("\n[green::b]✓ [-:-:-]%s\n", text)
+	return fmt.Sprintf("\n[green]%s[-:-:-]\n", text)
 }
 
 // TNewConversation TUI 新对话提示
 func TNewConversation() string {
-	return "\n[cyan::b]◈ [-:-:-]新对话已开始\n"
+	return "\n[cyan]新对话已开始[-:-:-]\n"
 }
 
 // TInterrupted TUI 中断提示
 func TInterrupted() string {
-	return "\n[yellow::b]⚠ [-:-:-]输入已打断\n"
+	return "\n[yellow]输入已打断[-:-:-]\n"
 }
 
 // TCancelled TUI 取消提示
 func TCancelled() string {
-	return "\n[yellow::b]⚠ [-:-:-]会话已取消\n"
+	return "\n[yellow]会话已取消[-:-:-]\n"
 }
+
+// ── bar 通知（单行、无首尾换行）─────────────────────────
+// 与消息区版本（TNewConversation / TCancelled / TSuccess）同色同文案，唯一差别是
+// 不带 \n —— bar 是 SetWrap(false) 的 TextView，换行会显示成空白或把内容顶出可视区。
+// 按"系统消息不带装饰符号"的规则，这里也不加任何符号前缀。
+//
+// 去符号之后 bar 版与消息区版的差别只剩首尾换行，因此不需要新的私有拼接函数，
+// 直接复用 TColoredText（其实现本就是 "[%s]%s[-:-:-]"）。
+//
+// 没有 TBarInterrupted：它唯一的潜在调用点（TInterrupted 的打印）已作为重复打印删除。
+
+// TBarNewConversation bar 版新对话提示（NoticeBar 文案统一小写英文）
+func TBarNewConversation() string { return TColoredText(TColorCyan, "new conversation started") }
+
+// TBarCancelled bar 版取消提示
+func TBarCancelled() string { return TColoredText(TColorYellow, "session cancelled") }
+
+// TBarSuccess bar 版成功提示
+func TBarSuccess(text string) string { return TColoredText(TColorGreen, text) }
 
 // ── 对话内容 ─────────────────────────────────
 
@@ -580,9 +610,9 @@ func TToolResult(text string) string {
 }
 
 // TToolCompact 紧凑单行工具渲染：绿点 + 橙色工具名 + 灰色参数/结果概要
-// 格式: ● name  args → resultSummary
+// 格式: ● name  args ↪ result（result 换行缩进显示）
 func TToolCompact(name string, args []byte, result string) string {
-	// ── 参数压缩：去换行、合并空格、截断 80；空/()/{} 不输出 ──
+	// ── 参数压缩：去换行、合并空格、截断 80 rune；空/()/{} 不输出 ──
 	var compactArgs string
 	if len(args) > 0 {
 		s := strings.ReplaceAll(string(args), "\n", " ")
@@ -596,7 +626,7 @@ func TToolCompact(name string, args []byte, result string) string {
 		}
 	}
 
-	// ── 结果：去换行、合并空格、截断 200；空/()/{} 不输出（与 args 同法）──
+	// ── 结果：去换行、合并空格、截断 200 rune；空/()/{} 不输出（与 args 同法）──
 	var resultSummary string
 	if result != "" {
 		s := strings.ReplaceAll(result, "\n", " ")
@@ -610,7 +640,7 @@ func TToolCompact(name string, args []byte, result string) string {
 		}
 	}
 
-	// 拼灰色尾部：有 result 才带 " → "（args 可空；仅 args 无 result 时无箭头）
+	// 拼灰色尾部：有 result 才换行带 "↪ "（args 可空；仅 args 无 result 时无箭头）
 	var tail string
 	switch {
 	case compactArgs != "" && resultSummary != "":


### PR DESCRIPTION
## 概述

将 HyperBot v3.0.0（commit 9f829f1 "优化TUI展示"）的 TUI 优化与重构**整体移植**到 HackerTeam，并适配多角色（Captain + 5 子 agent）架构。

## 移植内容

### TUI 层（service/tui + utils/pretty）
- **新布局**：移除装饰性 StatusBar 与 InputHint；新增 `TodoBar`（纵向清单，0~N 行动态高度，矮终端钳制防 Flex 负高度残影）、`NoticeBar`（常驻提示 + TTL 临时通知）、输入区左侧 2 列运行指示器（盲文 spinner）
- **重绘节流**：widget 写入改 `QueueUpdate` + `markDirty`，30ms `drawLoop` 节流重绘——流式输出从每 token 阻塞全屏重绘（O(n²)）降为固定帧率
- **glamour renderer 按宽度缓存**；宽度读取移入 `QueueUpdate` 消除与 draw loop 的数据竞争；渲染失败退回原文
- **banner.go（新增）**：启动横幅（logo/信息/键位面板三段拼版，窄终端自动降级），挂在 `Startup` turnCode 上必然只打一次
- **pretty.go**：系统消息去装饰符号（语义由颜色承载），新增 `TBar*` bar 版 helper

### 引擎层（适配多角色架构的差异处理）
- **todoTextSink**：`TodoStatusBar` 渲染统一为纵向多行，同一份文本注入 prompt 尾部 + 推给 TodoBar（空串也推，靠它塌回收起）；`members.go` 的 `setAgent` 仅 **Captain 挂 sink**，五个子 agent 传 nil（防子 agent 每跳推空串清掉清单造成闪烁）
- **错误自动重试**：`errorStreak`/`errorMaxTimes=3`/`errorSleepGap=3s`，四个归零时机（成功/new/ESC/用户重新输入）；`agentRunIteratively` 改 "Error 优先 + else 兜底" 结构
- **turnResult→turnInfo**（OutputPart→PartialOutput），新增 `Startup` turnCode；`randomStartID` 命名与 RequestId 机制保留（HackerTeam 特有）
- **输入复用收敛**：`InputChan`→未导出 `inputChan`，`ListenUserInput()` 合并焦点/捕获/取流
- **接口收敛**：`tuiService` 门面新增 5 方法/移除 5 方法；session 包改用单方法 `msgPrinter` 小接口；每类事件只在源头打印一次

## 验证

- [x] `go build ./cmd` 通过
- [x] `go vet ./...` 无告警
- [ ] 真机 TUI 视觉走查（横幅/spinner/TodoBar/NoticeBar）——建议 merge 前跑一次

## 差异保留说明

刻意未跟随 HyperBot 的部分：`RequestId` 机制与 `WithRequestID`（HackerTeam 的 Engine 结构独立持有 SessionId/RequestId）；`agent/` 目录透传包装的删除（HackerTeam 无此结构，模型装配在 members.go 的 setAgent）。
